### PR TITLE
feat: add provider test button and fix Authentik discovery

### DIFF
--- a/Jellyfin.Plugin.OIDC/Api/ConfigController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/ConfigController.cs
@@ -1,5 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using IdentityModel.Client;
 using Jellyfin.Plugin.OIDC.Services;
 using MediaBrowser.Common.Api;
 using Microsoft.AspNetCore.Authorization;
@@ -13,10 +16,12 @@ namespace Jellyfin.Plugin.OIDC.Api;
 public class ConfigController : ControllerBase
 {
     private readonly RbacService _rbacService;
+    private readonly IHttpClientFactory _httpClientFactory;
 
-    public ConfigController(RbacService rbacService)
+    public ConfigController(RbacService rbacService, IHttpClientFactory httpClientFactory)
     {
         _rbacService = rbacService;
+        _httpClientFactory = httpClientFactory;
     }
 
     [HttpGet("Libraries")]
@@ -38,4 +43,59 @@ public class ConfigController : ControllerBase
                                ?? new List<string>()
         });
     }
+
+    [HttpPost("TestProvider")]
+    public async Task<ActionResult> TestProvider([FromBody] ProviderTestRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Authority))
+        {
+            return Ok(new { Success = false, Error = "Authority URL is required" });
+        }
+
+        var httpClient = _httpClientFactory.CreateClient("OidcPlugin");
+        var disco = await httpClient.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest
+        {
+            Address = request.Authority,
+            Policy = new DiscoveryPolicy
+            {
+                ValidateIssuerName = true,
+                ValidateEndpoints = false
+            }
+        }).ConfigureAwait(false);
+
+        if (disco.IsError)
+        {
+            return Ok(new
+            {
+                Success = false,
+                Error = disco.Error,
+                ErrorType = disco.ErrorType.ToString()
+            });
+        }
+
+        var requestedScopes = (request.Scopes ?? string.Empty)
+            .Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+        var supportedScopes = disco.ScopesSupported?.ToList() ?? new List<string>();
+        var unsupportedScopes = supportedScopes.Count == 0
+            ? new List<string>()
+            : requestedScopes.Where(s => !supportedScopes.Contains(s)).ToList();
+
+        return Ok(new
+        {
+            Success = true,
+            Issuer = disco.Issuer,
+            AuthorizationEndpoint = disco.AuthorizeEndpoint,
+            TokenEndpoint = disco.TokenEndpoint,
+            UserInfoEndpoint = disco.UserInfoEndpoint,
+            JwksUri = disco.JwksUri,
+            ScopesSupported = supportedScopes,
+            UnsupportedRequestedScopes = unsupportedScopes
+        });
+    }
+}
+
+public class ProviderTestRequest
+{
+    public string Authority { get; set; } = string.Empty;
+    public string? Scopes { get; set; }
 }

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -280,7 +280,7 @@ public class OidcController : ControllerBase
             Policy = new DiscoveryPolicy
             {
                 ValidateIssuerName = true,
-                ValidateEndpoints = true
+                ValidateEndpoints = false
             }
         }).ConfigureAwait(false);
     }

--- a/Jellyfin.Plugin.OIDC/Configuration/oidcrbac.js
+++ b/Jellyfin.Plugin.OIDC/Configuration/oidcrbac.js
@@ -62,8 +62,10 @@ function renderProviders(view) {
             '<div class="oidc-field"><label><input type="checkbox" id="prov_enabled_' + idx + '"' +
             (p.Enabled !== false ? ' checked' : '') + '/> Enabled</label></div>' +
             '</div>' +
-            '<div style="margin-top:0.5em;">' +
+            '<div style="margin-top:0.5em;display:flex;gap:0.5em;align-items:center;">' +
+            '<button type="button" class="oidc-btn-secondary" data-action="test-provider" data-idx="' + idx + '">Test Connection</button>' +
             '<button type="button" class="oidc-btn-remove" data-action="remove-provider" data-idx="' + idx + '">Remove</button>' +
+            '<span class="oidc-test-result" data-idx="' + idx + '" style="font-size:0.9em;"></span>' +
             '</div>';
         container.appendChild(card);
     });
@@ -119,6 +121,55 @@ function renderRoleMappings(view) {
         container.appendChild(card);
         var libCont = view.querySelector('#role_libs_' + idx);
         selectedLibs.forEach(function (libId) { addLibChip(libCont, libId); });
+    });
+}
+
+function testProvider(view, idx) {
+    var authority = gval(view, 'prov_authority_' + idx);
+    var scopes = gval(view, 'prov_scopes_' + idx);
+    var resultEl = view.querySelector('.oidc-test-result[data-idx="' + idx + '"]');
+    if (!authority) {
+        if (resultEl) { resultEl.style.color = '#c62828'; resultEl.textContent = 'Authority URL is required'; }
+        return;
+    }
+    if (resultEl) { resultEl.style.color = '#888'; resultEl.textContent = 'Testing...'; }
+
+    ApiClient.ajax({
+        type: 'POST',
+        url: ApiClient.getUrl('sso/OIDC/Config/TestProvider'),
+        data: JSON.stringify({ Authority: authority, Scopes: scopes }),
+        contentType: 'application/json',
+        dataType: 'json'
+    }).then(function (result) {
+        if (result.Success) {
+            if (resultEl) {
+                resultEl.style.color = '#4caf50';
+                var msg = 'OK — issuer ' + result.Issuer;
+                if (result.UnsupportedRequestedScopes && result.UnsupportedRequestedScopes.length > 0) {
+                    msg += ' (warning: scopes not advertised: ' + result.UnsupportedRequestedScopes.join(', ') + ')';
+                    resultEl.style.color = '#ff9800';
+                }
+                resultEl.textContent = msg;
+            }
+            Dashboard.alert({
+                title: 'Provider OK',
+                message:
+                    'Issuer: ' + result.Issuer + '\n' +
+                    'Authorize: ' + result.AuthorizationEndpoint + '\n' +
+                    'Token: ' + result.TokenEndpoint + '\n' +
+                    (result.UserInfoEndpoint ? 'UserInfo: ' + result.UserInfoEndpoint + '\n' : '') +
+                    (result.UnsupportedRequestedScopes && result.UnsupportedRequestedScopes.length > 0
+                        ? '\nWarning: these requested scopes are not in scopes_supported:\n  ' + result.UnsupportedRequestedScopes.join(', ')
+                        : '')
+            });
+        } else {
+            if (resultEl) { resultEl.style.color = '#c62828'; resultEl.textContent = 'Failed: ' + result.Error; }
+            Dashboard.alert({ title: 'Provider test failed', message: result.Error || 'Unknown error' });
+        }
+    }).catch(function (err) {
+        var msg = (err && (err.statusText || err.message)) || 'Network error';
+        if (resultEl) { resultEl.style.color = '#c62828'; resultEl.textContent = 'Failed: ' + msg; }
+        Dashboard.alert({ title: 'Provider test failed', message: msg });
     });
 }
 
@@ -262,9 +313,12 @@ export default function (view) {
     view.querySelector('#providerList').addEventListener('click', function (e) {
         var btn = e.target.closest('[data-action]');
         if (!btn) return;
+        var idx = parseInt(btn.getAttribute('data-idx'));
         if (btn.getAttribute('data-action') === 'remove-provider') {
-            cfg.Providers.splice(parseInt(btn.getAttribute('data-idx')), 1);
+            cfg.Providers.splice(idx, 1);
             renderProviders(view);
+        } else if (btn.getAttribute('data-action') === 'test-provider') {
+            testProvider(view, idx);
         }
     });
 

--- a/Jellyfin.Plugin.OIDC/meta.json
+++ b/Jellyfin.Plugin.OIDC/meta.json
@@ -7,11 +7,11 @@
   "category": "Authentication",
   "versions": [
     {
-      "version": "1.0.0.1",
-      "changelog": "Initial release: OIDC auth with PKCE, role-based library access, multi-provider, admin UI",
+      "version": "1.0.1",
+      "changelog": "Fix Authentik discovery (relax endpoint validation); add Test Connection button on provider cards",
       "targetAbi": "10.11.0.0",
       "sourceUrl": "",
-      "timestamp": "2026-05-12T00:00:00Z"
+      "timestamp": "2026-05-18T00:00:00Z"
     }
   ],
   "status": "Active"

--- a/Jellyfin.Plugin.OIDC/meta.json
+++ b/Jellyfin.Plugin.OIDC/meta.json
@@ -7,7 +7,7 @@
   "category": "Authentication",
   "versions": [
     {
-      "version": "1.0.1",
+      "version": "1.0.1.0",
       "changelog": "Fix Authentik discovery (relax endpoint validation); add Test Connection button on provider cards",
       "targetAbi": "10.11.0.0",
       "sourceUrl": "",

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 name: "OIDC RBAC"
 guid: "d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90"
-version: "1.0.0.1"
+version: "1.0.1"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 owner: "Ezeqielle"

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 name: "OIDC RBAC"
 guid: "d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90"
-version: "1.0.1"
+version: "1.0.1.0"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 owner: "Ezeqielle"


### PR DESCRIPTION
## Summary
- Relax OIDC discovery endpoint validation so per-application IdPs like Authentik work — they publish per-app discovery docs but return global authorize/token endpoints, which tripped `ValidateEndpoints`. Issuer validation is kept, so the discovery doc is still pinned to the configured Authority.
- Add `POST /sso/OIDC/Config/TestProvider` admin-only endpoint and a **Test Connection** button on each provider card. Validates the currently-entered Authority/Scopes without needing to save first; reports resolved issuer/endpoints and warns on requested scopes not in `scopes_supported`.
- Bump version to 1.0.1.

## Test plan
- [ ] Plugin builds via `make docker-build`
- [ ] Authentik login succeeds (was failing with "Invalid base address for endpoint…")
- [ ] Test Connection shows green OK with issuer/endpoints for a valid provider
- [ ] Test Connection shows red error for an invalid Authority URL
- [ ] Scope warning appears when requesting a scope not in `scopes_supported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)