### PR TITLE
ci: bump action versions to Node.js 24-compatible majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.0.x"
 
@@ -60,7 +60,7 @@ jobs:
           EOF
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: oidc-rbac.zip
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/setup-dotnet` v4 → v5
- `softprops/action-gh-release` v2 → v3

The v1.0.2 release run surfaced a deprecation warning: Node.js 20 will be forced off GitHub runners on **2026-06-16**. These three actions still ran on Node 20 at their previous major versions — bumping to the new majors moves them onto Node 24-compatible builds.

## Test plan
- [ ] Tag a no-op test (or wait until the next real release tag) and confirm the workflow runs without the Node.js 20 deprecation warning
- [ ] Confirm the GitHub release + zip upload + `manifest.json` commit on `main` still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)