### PR TITLE
fix: resolve redirect_uri from Jellyfin's published URL (closes #3)

### DIFF
--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -11,6 +11,7 @@ using IdentityModel;
 using IdentityModel.Client;
 using Jellyfin.Plugin.OIDC.Configuration;
 using Jellyfin.Plugin.OIDC.Services;
+using MediaBrowser.Controller;
 using MediaBrowser.Controller.Session;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -29,6 +30,7 @@ public class OidcController : ControllerBase
     private readonly UserSyncService _userSyncService;
     private readonly ISessionManager _sessionManager;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IServerApplicationHost _appHost;
     private readonly ILogger<OidcController> _logger;
 
     public OidcController(
@@ -36,12 +38,14 @@ public class OidcController : ControllerBase
         UserSyncService userSyncService,
         ISessionManager sessionManager,
         IHttpClientFactory httpClientFactory,
+        IServerApplicationHost appHost,
         ILogger<OidcController> logger)
     {
         _stateManager = stateManager;
         _userSyncService = userSyncService;
         _sessionManager = sessionManager;
         _httpClientFactory = httpClientFactory;
+        _appHost = appHost;
         _logger = logger;
     }
 
@@ -64,7 +68,7 @@ public class OidcController : ControllerBase
         var codeVerifier = CryptoRandom.CreateUniqueId(64);
         var codeChallenge = CreateCodeChallenge(codeVerifier);
         var nonce = CryptoRandom.CreateUniqueId(32);
-        var redirectUri = BuildRedirectUri(providerId);
+        var redirectUri = BuildRedirectUri(provider);
 
         var state = new OidcState
         {
@@ -285,9 +289,13 @@ public class OidcController : ControllerBase
         }).ConfigureAwait(false);
     }
 
-    private string BuildRedirectUri(string providerId)
+    private string BuildRedirectUri(OidcProviderConfig provider)
     {
-        return $"{Request.Scheme}://{Request.Host}/sso/OIDC/Callback/{providerId}";
+        var baseUrl = !string.IsNullOrWhiteSpace(provider.ServerBaseUrl)
+            ? provider.ServerBaseUrl
+            : _appHost.GetSmartApiUrl(Request);
+
+        return $"{baseUrl.TrimEnd('/')}/sso/OIDC/Callback/{provider.ProviderId}";
     }
 
     private static string CreateCodeChallenge(string codeVerifier)

--- a/Jellyfin.Plugin.OIDC/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.OIDC/Configuration/PluginConfiguration.cs
@@ -43,6 +43,8 @@ public class OidcProviderConfig
     public string ButtonIcon { get; set; } = string.Empty;
 
     public string AdditionalParameters { get; set; } = string.Empty;
+
+    public string ServerBaseUrl { get; set; } = string.Empty;
 }
 
 public class RoleMapping

--- a/Jellyfin.Plugin.OIDC/Configuration/oidcrbac.js
+++ b/Jellyfin.Plugin.OIDC/Configuration/oidcrbac.js
@@ -59,6 +59,7 @@ function renderProviders(view) {
             fld('Display Name Claim', 'text', 'prov_displayclaim_' + idx, p.DisplayNameClaim || 'name', '') +
             fld('Button Color', 'color', 'prov_color_' + idx, p.ButtonColor || '#4285F4', '') +
             fld('Additional Params', 'text', 'prov_params_' + idx, p.AdditionalParameters || '', 'key=val&key2=val2', true) +
+            fld('Server Base URL (override)', 'text', 'prov_baseurl_' + idx, p.ServerBaseUrl || '', 'Optional: https://jellyfin.example.com (overrides auto-detected redirect_uri host)', true) +
             '<div class="oidc-field"><label><input type="checkbox" id="prov_enabled_' + idx + '"' +
             (p.Enabled !== false ? ' checked' : '') + '/> Enabled</label></div>' +
             '</div>' +
@@ -188,6 +189,7 @@ function collectProviders(view) {
             DisplayNameClaim: gval(view, 'prov_displayclaim_' + idx),
             ButtonColor: gval(view, 'prov_color_' + idx),
             AdditionalParameters: gval(view, 'prov_params_' + idx),
+            ServerBaseUrl: gval(view, 'prov_baseurl_' + idx),
             Enabled: gchk(view, 'prov_enabled_' + idx),
             ButtonIcon: ''
         });

--- a/Jellyfin.Plugin.OIDC/meta.json
+++ b/Jellyfin.Plugin.OIDC/meta.json
@@ -7,6 +7,13 @@
   "category": "Authentication",
   "versions": [
     {
+      "version": "1.0.3.0",
+      "changelog": "Fix redirect_uri host detection behind reverse proxies (use Jellyfin's published URL); add optional per-provider ServerBaseUrl override",
+      "targetAbi": "10.11.0.0",
+      "sourceUrl": "",
+      "timestamp": "2026-06-02T00:00:00Z"
+    },
+    {
       "version": "1.0.2.0",
       "changelog": "Update Jellyfin.Controller/Model to 10.11.10; fix ChangePassword call to use user ID",
       "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary

Fixes #3 — `redirect_uri` was `http://127.0.0.1:8096/...` instead of the public Jellyfin URL when behind a reverse proxy. Strict IdPs like Keycloak then rejected the callback. Authentik appeared to "work" because it's more permissive on redirect_uri matching — same bug, just silent there.

- **Root cause**: `OidcController.BuildRedirectUri` used `$"{Request.Scheme}://{Request.Host}/..."`, which is the inbound-socket Host. Without trusted `X-Forwarded-*` headers, that falls back to the listening address.
- **Fix**: inject `IServerApplicationHost` and call `GetSmartApiUrl(Request)`, which honors Jellyfin's "Published Server URLs" admin config and trusted forwarded headers.
- **Escape hatch**: optional `ServerBaseUrl` per provider — when set, takes precedence over auto-detection. Surfaced as a new field on the provider card.

Version bumped to `1.0.3.0`.

## Test plan
- [ ] Build passes (verified locally via `make package`)
- [ ] Behind a reverse proxy with no override set: `redirect_uri` matches Jellyfin's Published Server URL
- [ ] With `ServerBaseUrl` set: `redirect_uri` matches the override exactly
- [ ] Direct access (no proxy): `redirect_uri` still works (falls back to request host via `GetSmartApiUrl`)
- [ ] Keycloak end-to-end: callback succeeds without `Invalid redirect_uri`
- [ ] Authentik end-to-end: still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)