### PR TITLE
fix: preserve null MaxParentalRating when no mapping specifies one (closes #8)

### DIFF
--- a/Jellyfin.Plugin.OIDC/Services/RbacService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/RbacService.cs
@@ -151,9 +151,7 @@ public class RbacService
             EnableCollectionManagement = mappings.Any(m => m.EnableCollectionManagement),
             EnableSubtitleManagement = mappings.Any(m => m.EnableSubtitleManagement),
             MaxParentalRating = mappings
-                .Where(m => m.MaxParentalRating.HasValue)
-                .Select(m => m.MaxParentalRating!.Value)
-                .DefaultIfEmpty()
+                .Select(m => m.MaxParentalRating)
                 .Max(),
             LibraryIds = mappings
                 .SelectMany(m => m.LibraryIds)


### PR DESCRIPTION
## Summary

Fixes #8 — admins (and any user whose matched role mappings don't specify a rating) had their "Maximum allowed parental rating" silently clamped to **Approved/G/TV-G/TV-Y** on every OIDC login.

## Root cause

`MergeMappings` in `Services/RbacService.cs` computed `MaxParentalRating` like this:

```csharp
MaxParentalRating = mappings
    .Where(m => m.MaxParentalRating.HasValue)
    .Select(m => m.MaxParentalRating!.Value)   // → IEnumerable<int>
    .DefaultIfEmpty()                          // → { 0 } when empty
    .Max(),                                    // → 0
```

When no matched mapping sets `MaxParentalRating`, `DefaultIfEmpty().Max()` yields `0`. That `0` has `HasValue == true`, so the downstream guard sets `MaxParentalRatingScore = 0`, which maps to Jellyfin's lowest rating tier.

## Fix

```csharp
MaxParentalRating = mappings
    .Select(m => m.MaxParentalRating)          // → IEnumerable<int?>
    .Max(),                                    // → highest non-null, or null if all null/empty
```

`Max()` over `IEnumerable<int?>` ignores nulls and returns `null` when the sequence is empty or all-null. The existing `if (merged.MaxParentalRating.HasValue)` guard then correctly skips setting the score, leaving the user's rating untouched — which matches the intent: "take the highest rating from any matched mapping; if none specify, leave the existing value alone."

## Testing

Compiled via the project `Dockerfile` (.NET 9 SDK): `dotnet publish -c Release` succeeds with no warnings or errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)