### PR TITLE
fix: apply admin role when role claims span ID and access tokens

### DIFF
--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -175,12 +175,18 @@ public class OidcController : ControllerBase
 
         var displayName = ClaimParser.ExtractClaim(idToken, provider.DisplayNameClaim);
 
-        // Extract roles from both ID token and access token
+        // Extract roles from both the ID token and the access token, then union them.
+        // Providers differ in which token carries which claims (e.g. an admin group may
+        // land only in the access token), so relying on one token can silently drop roles.
         var roles = ClaimParser.ExtractRoles(idToken, provider.RoleClaim);
-        if (roles.Length == 0 && handler.CanReadToken(tokenResponse.AccessToken))
+        if (handler.CanReadToken(tokenResponse.AccessToken))
         {
             var accessToken = handler.ReadJwtToken(tokenResponse.AccessToken);
-            roles = ClaimParser.ExtractRoles(accessToken, provider.RoleClaim);
+            var accessRoles = ClaimParser.ExtractRoles(accessToken, provider.RoleClaim);
+            roles = roles
+                .Concat(accessRoles)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
         }
 
         _logger.LogInformation("OIDC auth successful: user={Username}, roles=[{Roles}], provider={Provider}",

--- a/Jellyfin.Plugin.OIDC/Services/RbacService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/RbacService.cs
@@ -65,6 +65,13 @@ public class RbacService
 
         var merged = MergeMappings(matchedMappings);
 
+        _logger.LogInformation(
+            "RBAC matched for user {Username}: roles=[{Roles}], matched mappings=[{Matched}], resolved admin={IsAdmin}",
+            user.Username,
+            string.Join(", ", userRoles),
+            string.Join(", ", matchedMappings.Select(m => m.RoleName)),
+            merged.IsAdmin);
+
         user.SetPermission(PermissionKind.IsAdministrator, merged.IsAdmin);
         user.SetPermission(PermissionKind.EnableMediaPlayback, merged.EnableMediaPlayback);
         user.SetPermission(PermissionKind.EnableRemoteAccess, merged.EnableRemoteAccess);
@@ -76,7 +83,9 @@ public class RbacService
         user.SetPermission(PermissionKind.EnableCollectionManagement, merged.EnableCollectionManagement);
         user.SetPermission(PermissionKind.EnableSubtitleManagement, merged.EnableSubtitleManagement);
 
-        if (merged.EnableAllLibraries)
+        // Administrators can access every library regardless of folder settings.
+        // Force EnableAllFolders on for admins so the policy state stays consistent.
+        if (merged.EnableAllLibraries || merged.IsAdmin)
         {
             user.SetPermission(PermissionKind.EnableAllFolders, true);
         }

--- a/Jellyfin.Plugin.OIDC/meta.json
+++ b/Jellyfin.Plugin.OIDC/meta.json
@@ -7,6 +7,13 @@
   "category": "Authentication",
   "versions": [
     {
+      "version": "1.0.5.0",
+      "changelog": "Fix admin role not being applied when role claims are split across the ID and access tokens (union roles from both); force EnableAllFolders for administrators; add RBAC diagnostic logging",
+      "targetAbi": "10.11.0.0",
+      "sourceUrl": "",
+      "timestamp": "2026-07-05T00:00:00Z"
+    },
+    {
       "version": "1.0.3.0",
       "changelog": "Fix redirect_uri host detection behind reverse proxies (use Jellyfin's published URL); add optional per-provider ServerBaseUrl override",
       "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary

Fixes #12 — administrators intermittently did not receive the admin permission (and lost dashboard access).

### Root cause
In `OidcController.Callback`, roles were extracted from the access token **only when the ID token returned zero roles**. When a provider split claims so the ID token carried a *partial* role set (e.g. `jellyfin-users`) while the admin group (`jellyfin-admins`) lived only in the access token, the admin role was silently dropped. Whether the admin claim landed in the ID token vs the access token depends on the IdP's scope/claim mapping — which is why it presented as "**often** doesn't give admin" rather than always.

### Changes
- **Union roles from both tokens** (`Api/OidcController.cs`) — extract from the ID token *and* the access token, then distinct-merge case-insensitively. This is the primary fix.
- **Normalize admin policy** (`Services/RbacService.cs`) — force `EnableAllFolders` on for administrators so an admin with "All Libraries" unchecked no longer lands in a contradictory policy state.
- **Diagnostic logging** (`Services/RbacService.cs`) — log the raw roles, matched mapping names, and resolved admin flag to make any recurrence traceable.
- Bump `meta.json` to `1.0.5.0`.

### Verification
- Built via `make docker-build`; compiles cleanly and produces `Jellyfin.Plugin.OIDC.dll`.
- The live OIDC login flow was not exercised end-to-end (requires a running Jellyfin instance + live IdP); runtime behavior verified by build + code inspection.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)