### PR TITLE
fix: persist role mappings & fix new-user login 500 (v1.0.6)

### DIFF
--- a/Jellyfin.Plugin.OIDC/Services/RbacService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/RbacService.cs
@@ -6,6 +6,7 @@ using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.OIDC.Configuration;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Users;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.OIDC.Services;
@@ -41,6 +42,15 @@ public class RbacService
             return;
         }
 
+        // Read the user's current policy and mutate only the fields we manage. Persistence MUST
+        // go through UpdatePolicyAsync: IUserManager.UpdateUserAsync only writes the root User row
+        // and silently drops Permission/Preference changes (admin flag, enabled folders, ...),
+        // which would leave users on Jellyfin's permissive default (access to all libraries).
+        var policy = _userManager.GetUserDto(user).Policy;
+
+        // OIDC-authenticated users are always enabled on login.
+        policy.IsDisabled = false;
+
         var matchedMappings = config.RoleMappings
             .Where(m => userRoles.Contains(m.RoleName, StringComparer.OrdinalIgnoreCase))
             .OrderByDescending(m => m.Priority)
@@ -58,8 +68,9 @@ public class RbacService
 
         if (matchedMappings.Count == 0)
         {
-            _logger.LogInformation("No role mappings matched for user {Username} with roles [{Roles}]",
+            _logger.LogInformation("No role mappings matched for user {Username} with roles [{Roles}]; leaving permissions unchanged",
                 user.Username, string.Join(", ", userRoles));
+            await _userManager.UpdatePolicyAsync(userId, policy).ConfigureAwait(false);
             return;
         }
 
@@ -72,42 +83,46 @@ public class RbacService
             string.Join(", ", matchedMappings.Select(m => m.RoleName)),
             merged.IsAdmin);
 
-        user.SetPermission(PermissionKind.IsAdministrator, merged.IsAdmin);
-        user.SetPermission(PermissionKind.EnableMediaPlayback, merged.EnableMediaPlayback);
-        user.SetPermission(PermissionKind.EnableRemoteAccess, merged.EnableRemoteAccess);
-        user.SetPermission(PermissionKind.EnableAudioPlaybackTranscoding, merged.EnableTranscoding);
-        user.SetPermission(PermissionKind.EnableVideoPlaybackTranscoding, merged.EnableTranscoding);
-        user.SetPermission(PermissionKind.EnableLiveTvAccess, merged.EnableLiveTv);
-        user.SetPermission(PermissionKind.EnableLiveTvManagement, merged.EnableLiveTvManagement);
-        user.SetPermission(PermissionKind.EnableContentDeletion, merged.EnableContentDeletion);
-        user.SetPermission(PermissionKind.EnableCollectionManagement, merged.EnableCollectionManagement);
-        user.SetPermission(PermissionKind.EnableSubtitleManagement, merged.EnableSubtitleManagement);
+        policy.IsAdministrator = merged.IsAdmin;
+        policy.EnableMediaPlayback = merged.EnableMediaPlayback;
+        policy.EnableRemoteAccess = merged.EnableRemoteAccess;
+        policy.EnableAudioPlaybackTranscoding = merged.EnableTranscoding;
+        policy.EnableVideoPlaybackTranscoding = merged.EnableTranscoding;
+        policy.EnableLiveTvAccess = merged.EnableLiveTv;
+        policy.EnableLiveTvManagement = merged.EnableLiveTvManagement;
+        policy.EnableContentDeletion = merged.EnableContentDeletion;
+        policy.EnableCollectionManagement = merged.EnableCollectionManagement;
+        policy.EnableSubtitleManagement = merged.EnableSubtitleManagement;
 
         // Administrators can access every library regardless of folder settings.
         // Force EnableAllFolders on for admins so the policy state stays consistent.
         if (merged.EnableAllLibraries || merged.IsAdmin)
         {
-            user.SetPermission(PermissionKind.EnableAllFolders, true);
+            policy.EnableAllFolders = true;
+            policy.EnabledFolders = Array.Empty<Guid>();
         }
         else
         {
-            user.SetPermission(PermissionKind.EnableAllFolders, false);
-            var resolvedIds = ResolveLibraryIds(merged.LibraryIds, merged.LibraryNames);
-            user.SetPreference(PreferenceKind.EnabledFolders, resolvedIds.ToArray());
+            policy.EnableAllFolders = false;
+            policy.EnabledFolders = ResolveLibraryIds(merged.LibraryIds, merged.LibraryNames)
+                .Select(id => Guid.TryParse(id, out var g) ? (Guid?)g : null)
+                .Where(g => g.HasValue)
+                .Select(g => g!.Value)
+                .ToArray();
         }
 
         if (merged.MaxParentalRating.HasValue)
         {
-            user.MaxParentalRatingScore = merged.MaxParentalRating;
+            policy.MaxParentalRating = merged.MaxParentalRating;
         }
 
-        await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+        await _userManager.UpdatePolicyAsync(userId, policy).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Applied RBAC for user {Username}: admin={IsAdmin}, libraries={LibraryCount}, roles matched=[{Roles}]",
             user.Username,
             merged.IsAdmin,
-            merged.EnableAllLibraries ? "ALL" : merged.LibraryIds.Count.ToString(),
+            merged.EnableAllLibraries || merged.IsAdmin ? "ALL" : policy.EnabledFolders.Length.ToString(),
             string.Join(", ", matchedMappings.Select(m => m.RoleName)));
     }
 

--- a/Jellyfin.Plugin.OIDC/Services/UserSyncService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/UserSyncService.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
-using Jellyfin.Data;
-using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
 
@@ -27,6 +26,7 @@ public class UserSyncService
     public async Task<Guid> SyncUserAsync(string username, string? displayName, string[] roles)
     {
         var user = _userManager.GetUserByName(username);
+        var isNewUser = user == null;
 
         if (user == null)
         {
@@ -38,7 +38,6 @@ public class UserSyncService
             }
 
             user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
-            user.AuthenticationProviderId = typeof(Auth.OidcAuthProvider).FullName!;
 
             var randomPassword = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
             await _userManager.ChangePassword(user.Id, randomPassword).ConfigureAwait(false);
@@ -46,18 +45,50 @@ public class UserSyncService
             _logger.LogInformation("Created new OIDC user: {Username}", username);
         }
 
-        if (!string.IsNullOrWhiteSpace(displayName))
+        var userId = user.Id;
+
+        if (isNewUser)
         {
-            // Only update if the display name is not already set or is different
-            // The User entity doesn't expose DisplayName directly; it's part of the DTO
-            // We skip display name update here as it requires additional API surface
+            // AuthenticationProviderId is a scalar on the User row, so UpdateUserAsync persists
+            // it correctly (child permissions do NOT persist that way — RBAC handles those via
+            // UpdatePolicyAsync). Jellyfin's UserManager uses a fresh DbContext per call with an
+            // optimistic-concurrency token, and CreateUserAsync + ChangePassword advance the row
+            // version, leaving the instance we hold stale — so re-fetch a fresh copy and retry.
+            await UpdateUserResilientAsync(
+                userId,
+                u => u.AuthenticationProviderId = typeof(Auth.OidcAuthProvider).FullName!)
+                .ConfigureAwait(false);
         }
 
-        user.SetPermission(PermissionKind.IsDisabled, false);
+        // RBAC applies permissions/library access and re-enables the account, persisting via
+        // UpdatePolicyAsync (the only path that saves Permission/Preference changes).
+        await _rbacService.ApplyRoleMappingsAsync(userId, roles).ConfigureAwait(false);
 
-        await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
-        await _rbacService.ApplyRoleMappingsAsync(user.Id, roles).ConfigureAwait(false);
+        return userId;
+    }
 
-        return user.Id;
+    private async Task UpdateUserResilientAsync(Guid userId, Action<User> mutate)
+    {
+        const int maxAttempts = 3;
+        for (var attempt = 1; ; attempt++)
+        {
+            var user = _userManager.GetUserById(userId)
+                ?? throw new InvalidOperationException($"User '{userId}' not found during sync");
+
+            mutate(user);
+
+            try
+            {
+                await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+                return;
+            }
+            catch (Exception ex) when (attempt < maxAttempts
+                && ex.GetType().Name == "DbUpdateConcurrencyException")
+            {
+                _logger.LogWarning(
+                    "Concurrency conflict updating user {UserId} (attempt {Attempt}); retrying with a fresh copy",
+                    userId, attempt);
+            }
+        }
     }
 }

--- a/Jellyfin.Plugin.OIDC/meta.json
+++ b/Jellyfin.Plugin.OIDC/meta.json
@@ -7,6 +7,13 @@
   "category": "Authentication",
   "versions": [
     {
+      "version": "1.0.6.0",
+      "changelog": "Fix new-user OIDC login failing with a 500 (DbUpdateConcurrencyException) by re-fetching a fresh user copy and retrying on conflict; fix role mappings never persisting (admin flag, permissions and per-role library access) by saving via UpdatePolicyAsync instead of UpdateUserAsync",
+      "targetAbi": "10.11.0.0",
+      "sourceUrl": "",
+      "timestamp": "2026-07-08T00:00:00Z"
+    },
+    {
       "version": "1.0.5.0",
       "changelog": "Fix admin role not being applied when role claims are split across the ID and access tokens (union roles from both); force EnableAllFolders for administrators; add RBAC diagnostic logging",
       "targetAbi": "10.11.0.0",

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 name: "OIDC RBAC"
 guid: "d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90"
-version: "1.0.1.0"
+version: "1.0.6.0"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 owner: "Ezeqielle"


### PR DESCRIPTION
## Summary

Two correctness bugs made OIDC user provisioning unreliable. Both are fixed here and verified against a live Jellyfin **10.11.10** instance.

### 1. New-user login returned HTTP 500
`UserManager.CreateUserAsync` and `ChangePassword` each persist through their own `DbContext` and advance the `User` row's optimistic-concurrency token. The plugin then called `UpdateUserAsync` with the now-stale entity, throwing:

```
DbUpdateConcurrencyException: ... expected to affect 1 row(s), but actually affected 0 row(s)
```

**Fix:** re-fetch a fresh user copy for the update and retry on conflict (`UpdateUserResilientAsync`).

### 2. Role mappings never persisted (⚠️ over-permissive users)
`RbacService` set permissions/preferences on a **detached** `User` and saved via `IUserManager.UpdateUserAsync`, which only writes the root `User` row (`Attach` + `State = Modified`) and **silently drops** child `Permission`/`Preference` changes. As a result the admin flag, playback/transcoding permissions and the **per-role library allow-list** were all discarded, leaving users on Jellyfin's default policy — i.e. access to **all** libraries.

**Fix:** persist via `IUserManager.UpdatePolicyAsync` (read current policy with `GetUserDto`, mutate managed fields, write back) — the same read-modify-write path Jellyfin core uses, which cascades to the child tables. `EnabledFolders` is now written as `Guid[]`.

## Verification
On a live Jellyfin 10.11.10 server (linuxserver image, Authentik IdP):
- Before: new user hit the 500; after manually working around it, the account had `EnableAllFolders=1` and an empty `EnabledFolders` (full access).
- After: new user logs in without error; DB shows `EnableAllFolders=0` and `EnabledFolders` = the role's mapped library IDs. Admin/permission flags apply as configured.

## Notes
- Bumps version to **1.0.6.0** (`build.yaml`, `meta.json`).
- Scope is limited to the login/RBAC persistence fix. The separate profile-image-from-`picture`-claim feature (issue #16) is tracked on its own branch/PR.