### PR TITLE
feat: sync user profile image from OIDC picture claim (#16)

### DIFF
--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -189,6 +189,48 @@ public class OidcController : ControllerBase
                 .ToArray();
         }
 
+        // Optionally extract the profile-image URL (standard OIDC "picture" claim). Like roles,
+        // check the ID token first and fall back to the access token, since providers differ
+        // in which token carries the claim.
+        string? pictureUrl = null;
+        if (provider.SyncProfileImage && !string.IsNullOrWhiteSpace(provider.PictureClaim))
+        {
+            pictureUrl = ClaimParser.ExtractClaim(idToken, provider.PictureClaim);
+            if (string.IsNullOrEmpty(pictureUrl) && handler.CanReadToken(tokenResponse.AccessToken))
+            {
+                pictureUrl = ClaimParser.ExtractClaim(
+                    handler.ReadJwtToken(tokenResponse.AccessToken), provider.PictureClaim);
+            }
+
+            // Many providers (e.g. Authentik) expose the picture only via the userinfo
+            // endpoint, not in the tokens. Fall back to userinfo when it's in neither token.
+            if (string.IsNullOrEmpty(pictureUrl)
+                && !string.IsNullOrEmpty(disco.UserInfoEndpoint)
+                && !string.IsNullOrEmpty(tokenResponse.AccessToken))
+            {
+                var userInfo = await httpClient.GetUserInfoAsync(new UserInfoRequest
+                {
+                    Address = disco.UserInfoEndpoint,
+                    Token = tokenResponse.AccessToken
+                }).ConfigureAwait(false);
+
+                if (userInfo.IsError)
+                {
+                    _logger.LogWarning("OIDC userinfo request failed: {Error}", userInfo.Error);
+                }
+                else
+                {
+                    pictureUrl = userInfo.Claims
+                        .FirstOrDefault(c => c.Type == provider.PictureClaim)?.Value;
+                }
+            }
+
+            _logger.LogInformation(
+                "OIDC picture claim '{Claim}' for user {User}: {Result}",
+                provider.PictureClaim, username,
+                string.IsNullOrEmpty(pictureUrl) ? "not found in token or userinfo" : pictureUrl);
+        }
+
         _logger.LogInformation("OIDC auth successful: user={Username}, roles=[{Roles}], provider={Provider}",
             username, string.Join(", ", roles), providerId);
 
@@ -197,6 +239,7 @@ public class OidcController : ControllerBase
             ProviderId = providerId,
             Username = username,
             DisplayName = displayName,
+            PictureUrl = string.IsNullOrEmpty(pictureUrl) ? null : pictureUrl,
             Roles = roles
         });
 
@@ -224,7 +267,8 @@ public class OidcController : ControllerBase
             var userId = await _userSyncService.SyncUserAsync(
                 session.Username,
                 session.DisplayName,
-                session.Roles).ConfigureAwait(false);
+                session.Roles,
+                session.PictureUrl).ConfigureAwait(false);
 
             var authRequest = new AuthenticationRequest
             {

--- a/Jellyfin.Plugin.OIDC/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.OIDC/Configuration/PluginConfiguration.cs
@@ -36,6 +36,10 @@ public class OidcProviderConfig
 
     public string DisplayNameClaim { get; set; } = "name";
 
+    public string PictureClaim { get; set; } = "picture";
+
+    public bool SyncProfileImage { get; set; } = true;
+
     public bool Enabled { get; set; } = true;
 
     public string ButtonColor { get; set; } = "#4285F4";

--- a/Jellyfin.Plugin.OIDC/Configuration/oidcrbac.js
+++ b/Jellyfin.Plugin.OIDC/Configuration/oidcrbac.js
@@ -57,9 +57,12 @@ function renderProviders(view) {
             fld('Role Claim Path', 'text', 'prov_roleclaim_' + idx, p.RoleClaim || 'groups', 'e.g. groups or realm_access.roles') +
             fld('Username Claim', 'text', 'prov_userclaim_' + idx, p.UsernameClaim || 'preferred_username', '') +
             fld('Display Name Claim', 'text', 'prov_displayclaim_' + idx, p.DisplayNameClaim || 'name', '') +
+            fld('Picture Claim', 'text', 'prov_pictureclaim_' + idx, p.PictureClaim || 'picture', 'e.g. picture') +
             fld('Button Color', 'color', 'prov_color_' + idx, p.ButtonColor || '#4285F4', '') +
             fld('Additional Params', 'text', 'prov_params_' + idx, p.AdditionalParameters || '', 'key=val&key2=val2', true) +
             fld('Server Base URL (override)', 'text', 'prov_baseurl_' + idx, p.ServerBaseUrl || '', 'Optional: https://jellyfin.example.com (overrides auto-detected redirect_uri host)', true) +
+            '<div class="oidc-field"><label><input type="checkbox" id="prov_syncimage_' + idx + '"' +
+            (p.SyncProfileImage !== false ? ' checked' : '') + '/> Sync profile image</label></div>' +
             '<div class="oidc-field"><label><input type="checkbox" id="prov_enabled_' + idx + '"' +
             (p.Enabled !== false ? ' checked' : '') + '/> Enabled</label></div>' +
             '</div>' +
@@ -187,6 +190,8 @@ function collectProviders(view) {
             RoleClaim: gval(view, 'prov_roleclaim_' + idx),
             UsernameClaim: gval(view, 'prov_userclaim_' + idx),
             DisplayNameClaim: gval(view, 'prov_displayclaim_' + idx),
+            PictureClaim: gval(view, 'prov_pictureclaim_' + idx),
+            SyncProfileImage: gchk(view, 'prov_syncimage_' + idx),
             ButtonColor: gval(view, 'prov_color_' + idx),
             AdditionalParameters: gval(view, 'prov_params_' + idx),
             ServerBaseUrl: gval(view, 'prov_baseurl_' + idx),
@@ -273,7 +278,8 @@ export default function (view) {
             ProviderId: '', DisplayName: 'New Provider', Authority: '',
             ClientId: '', ClientSecret: '', Scopes: 'openid profile email',
             RoleClaim: 'groups', UsernameClaim: 'preferred_username',
-            DisplayNameClaim: 'name', Enabled: true, ButtonColor: '#4285F4',
+            DisplayNameClaim: 'name', PictureClaim: 'picture', SyncProfileImage: true,
+            Enabled: true, ButtonColor: '#4285F4',
             ButtonIcon: '', AdditionalParameters: ''
         });
         renderProviders(view);

--- a/Jellyfin.Plugin.OIDC/Services/ProfileImageService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/ProfileImageService.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.OIDC.Services;
+
+public class ProfileImageService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IUserManager _userManager;
+    private readonly IServerConfigurationManager _serverConfigurationManager;
+    private readonly IProviderManager _providerManager;
+    private readonly ILogger<ProfileImageService> _logger;
+
+    public ProfileImageService(
+        IHttpClientFactory httpClientFactory,
+        IUserManager userManager,
+        IServerConfigurationManager serverConfigurationManager,
+        IProviderManager providerManager,
+        ILogger<ProfileImageService> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _userManager = userManager;
+        _serverConfigurationManager = serverConfigurationManager;
+        _providerManager = providerManager;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Downloads the image at <paramref name="pictureUrl"/> and sets it as the user's profile
+    /// image, overwriting any existing one. Never throws: avatar sync must not break login.
+    /// </summary>
+    public async Task ApplyProfileImageAsync(Guid userId, string? pictureUrl)
+    {
+        if (string.IsNullOrWhiteSpace(pictureUrl))
+        {
+            return;
+        }
+
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient("OidcPlugin");
+            using var response = await httpClient.GetAsync(pictureUrl).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Failed to download profile image from {Url}: HTTP {Status}",
+                    pictureUrl, (int)response.StatusCode);
+                return;
+            }
+
+            var mimeType = response.Content.Headers.ContentType?.MediaType;
+            if (string.IsNullOrEmpty(mimeType) || !mimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(
+                    "Profile image URL {Url} returned non-image content type '{ContentType}'",
+                    pictureUrl, mimeType ?? "(none)");
+                return;
+            }
+
+            var extension = GetExtensionForMimeType(mimeType);
+
+            var user = _userManager.GetUserById(userId);
+            if (user == null)
+            {
+                _logger.LogWarning("User {UserId} not found while applying profile image", userId);
+                return;
+            }
+
+            var userDataPath = Path.Combine(
+                _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath,
+                user.Username);
+            var imagePath = Path.Combine(userDataPath, "profile" + extension);
+
+            if (user.ProfileImage is not null)
+            {
+                await _userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
+            }
+
+            user.ProfileImage = new ImageInfo(imagePath);
+
+            var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            await using (stream.ConfigureAwait(false))
+            {
+                await _providerManager.SaveImage(stream, mimeType, user.ProfileImage.Path).ConfigureAwait(false);
+            }
+
+            await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+
+            _logger.LogInformation("Applied OIDC profile image for user {Username}", user.Username);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to apply profile image from {Url}", pictureUrl);
+        }
+    }
+
+    private static string GetExtensionForMimeType(string mimeType)
+    {
+        return mimeType.ToLowerInvariant() switch
+        {
+            "image/png" => ".png",
+            "image/gif" => ".gif",
+            "image/webp" => ".webp",
+            "image/jpg" or "image/jpeg" => ".jpg",
+            _ => ".jpg"
+        };
+    }
+}

--- a/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
@@ -11,6 +11,7 @@ public class ServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<StateManager>();
         serviceCollection.AddHostedService(sp => sp.GetRequiredService<StateManager>());
         serviceCollection.AddScoped<RbacService>();
+        serviceCollection.AddScoped<ProfileImageService>();
         serviceCollection.AddScoped<UserSyncService>();
     }
 }

--- a/Jellyfin.Plugin.OIDC/Services/StateManager.cs
+++ b/Jellyfin.Plugin.OIDC/Services/StateManager.cs
@@ -21,6 +21,7 @@ public sealed class AuthorizedSession
     public required string ProviderId { get; init; }
     public required string Username { get; init; }
     public string? DisplayName { get; init; }
+    public string? PictureUrl { get; init; }
     public required string[] Roles { get; init; }
     public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
 }

--- a/Jellyfin.Plugin.OIDC/Services/UserSyncService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/UserSyncService.cs
@@ -11,19 +11,22 @@ public class UserSyncService
 {
     private readonly IUserManager _userManager;
     private readonly RbacService _rbacService;
+    private readonly ProfileImageService _profileImageService;
     private readonly ILogger<UserSyncService> _logger;
 
     public UserSyncService(
         IUserManager userManager,
         RbacService rbacService,
+        ProfileImageService profileImageService,
         ILogger<UserSyncService> logger)
     {
         _userManager = userManager;
         _rbacService = rbacService;
+        _profileImageService = profileImageService;
         _logger = logger;
     }
 
-    public async Task<Guid> SyncUserAsync(string username, string? displayName, string[] roles)
+    public async Task<Guid> SyncUserAsync(string username, string? displayName, string[] roles, string? pictureUrl)
     {
         var user = _userManager.GetUserByName(username);
         var isNewUser = user == null;
@@ -50,10 +53,10 @@ public class UserSyncService
         if (isNewUser)
         {
             // AuthenticationProviderId is a scalar on the User row, so UpdateUserAsync persists
-            // it correctly (child permissions do NOT persist that way — RBAC handles those via
-            // UpdatePolicyAsync). Jellyfin's UserManager uses a fresh DbContext per call with an
-            // optimistic-concurrency token, and CreateUserAsync + ChangePassword advance the row
-            // version, leaving the instance we hold stale — so re-fetch a fresh copy and retry.
+            // it correctly (child permissions do not persist that way — RBAC handles those via
+            // UpdatePolicyAsync below). Jellyfin's UserManager uses a fresh DbContext per call
+            // with an optimistic-concurrency token, and CreateUserAsync + ChangePassword advance
+            // the row version, leaving the instance we hold stale — so re-fetch and retry.
             await UpdateUserResilientAsync(
                 userId,
                 u => u.AuthenticationProviderId = typeof(Auth.OidcAuthProvider).FullName!)
@@ -63,6 +66,7 @@ public class UserSyncService
         // RBAC applies permissions/library access and re-enables the account, persisting via
         // UpdatePolicyAsync (the only path that saves Permission/Preference changes).
         await _rbacService.ApplyRoleMappingsAsync(userId, roles).ConfigureAwait(false);
+        await _profileImageService.ApplyProfileImageAsync(userId, pictureUrl).ConfigureAwait(false);
 
         return userId;
     }

--- a/Jellyfin.Plugin.OIDC/meta.json
+++ b/Jellyfin.Plugin.OIDC/meta.json
@@ -7,6 +7,13 @@
   "category": "Authentication",
   "versions": [
     {
+      "version": "1.0.7.0",
+      "changelog": "Add optional profile-image sync: set a user's Jellyfin avatar from the OIDC picture claim on each login (per-provider Picture Claim field + Sync profile image toggle). Reads the ID token, access token, then the userinfo endpoint; failures never block login",
+      "targetAbi": "10.11.0.0",
+      "sourceUrl": "",
+      "timestamp": "2026-07-08T00:00:00Z"
+    },
+    {
       "version": "1.0.6.0",
       "changelog": "Fix new-user OIDC login failing with a 500 (DbUpdateConcurrencyException) by re-fetching a fresh user copy and retrying on conflict; fix role mappings never persisting (admin flag, permissions and per-role library access) by saving via UpdatePolicyAsync instead of UpdateUserAsync",
       "targetAbi": "10.11.0.0",

--- a/README.md
+++ b/README.md
@@ -61,9 +61,26 @@ Go to **Admin Dashboard > Plugins > OIDC RBAC > Providers tab**
 | Scopes             | `openid profile email`                                     |
 | Role Claim Path    | `groups`                                                   |
 | Username Claim     | `preferred_username`                                       |
+| Picture Claim      | `picture`                                                  |
+| Sync profile image | *(checkbox, on by default)*                                |
 | Server Base URL    | *(optional, e.g. `https://jellyfin.example.com`)*          |
 
 > **Server Base URL** is only needed if Jellyfin can't resolve its public URL on its own (e.g. behind a reverse proxy whose `X-Forwarded-*` headers aren't trusted). See [Reverse proxy / redirect_uri](#reverse-proxy--redirect_uri).
+
+### Profile image sync
+
+When **Sync profile image** is enabled, on every login the plugin reads the **Picture Claim**
+(default `picture`, the standard OIDC avatar claim) and sets it as the user's Jellyfin avatar,
+overwriting any existing one. It looks in the ID token, then the access token, then the
+provider's **userinfo** endpoint. Failures never block login. Leave the claim blank or uncheck
+the box to disable it for a provider.
+
+> The provider must actually emit the claim. Many IdPs do not include `picture` by default:
+> - **Authentik** — its default `profile` scope omits `picture`. Add a Scope Mapping (scope
+>   name `profile`) with expression `return {"picture": request.user.avatar}`.
+> - **Keycloak** — add a "User Attribute"/hardcoded mapper that puts a `picture` claim in the
+>   ID token or userinfo.
+> - **Google** — includes `picture` in the ID token by default.
 
 ### 2. Create Role Mappings
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ provider's **userinfo** endpoint. Failures never block login. Leave the claim bl
 the box to disable it for a provider.
 
 > The provider must actually emit the claim. Many IdPs do not include `picture` by default:
-> - **Authentik** — its default `profile` scope omits `picture`. Add a Scope Mapping (scope
->   name `profile`) with expression `return {"picture": request.user.avatar}`.
+> - **Authentik** — its default `profile` scope omits `picture`. Add a Scope Mapping and attach
+>   it to the provider — see [Authentik: Profile Picture / Avatar](examples/authentik/SETUP.md#25-optional-profile-picture--avatar).
 > - **Keycloak** — add a "User Attribute"/hardcoded mapper that puts a `picture` claim in the
 >   ID token or userinfo.
 > - **Google** — includes `picture` in the ID token by default.

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 name: "OIDC RBAC"
 guid: "d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90"
-version: "1.0.6.0"
+version: "1.0.7.0"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 owner: "Ezeqielle"

--- a/examples/authentik/SETUP.md
+++ b/examples/authentik/SETUP.md
@@ -118,6 +118,38 @@ Update the plugin config:
 - Scopes: `openid profile email jellyfin-roles`
 - Role Claim Path: `roles`
 
+### 2.5 (Optional) Profile Picture / Avatar
+
+The plugin can set each user's Jellyfin avatar from the OIDC `picture` claim on every login
+(see [Profile image sync](../../README.md#profile-image-sync)). **Authentik does not emit
+`picture` by default** — its built-in `profile` scope has no avatar claim — so you must add one.
+
+1. Go to **Customization > Property Mappings > Create > Scope Mapping**
+   - Name: `OIDC profile picture`
+   - Scope name: `profile`  *(reuse the scope the plugin already requests)*
+   - Expression:
+     ```python
+     return {"picture": request.user.avatar}
+     ```
+2. **Attach the mapping to the provider** — creating it is not enough. Go to
+   **Applications > Providers > _your Jellyfin provider_ > Edit > Advanced protocol settings**
+   and add `OIDC profile picture` to **Selected Scopes** (keep `openid`, `email`, and the
+   default `profile` selected as well). Save.
+3. Make sure Authentik actually produces an avatar URL. Under
+   **Admin > System > Settings > Avatars**, a value like `gravatar,initials` always yields a
+   URL; if it is set to an attribute that's empty for the user, `request.user.avatar` comes
+   back blank and nothing is synced.
+
+In the plugin's provider config, leave **Picture Claim** as `picture` and keep **Sync profile
+image** checked (both are the defaults). No extra scope is needed because the mapping reuses
+`profile`.
+
+Verify from the Jellyfin server logs on the next login:
+```
+OIDC picture claim 'picture' for user "<name>": https://www.gravatar.com/avatar/...
+ProfileImageService: Applied OIDC profile image for user "<name>"
+```
+
 ---
 
 ## 3. Configure the Jellyfin Plugin


### PR DESCRIPTION
Closes #16.

## Summary
Optionally set a user's Jellyfin avatar from the OIDC **picture** claim on each login.

- Per-provider **Picture Claim** field (default `picture`) and **Sync profile image** toggle in the admin UI.
- On login the value is resolved from the **ID token → access token → userinfo endpoint** (many IdPs only expose `picture` via userinfo).
- Downloads the image and sets it via Jellyfin's own pattern (`IProviderManager.SaveImage` into the user config dir + `User.ProfileImage`), overwriting any existing avatar.
- Fully guarded: a missing claim, non-image content type, or a slow/broken image host is logged and **never blocks login**.

## Changes
- `PluginConfiguration` — `PictureClaim`, `SyncProfileImage`.
- `oidcrbac.js` — new field + checkbox (render/collect/defaults).
- `OidcController` — resolve the picture URL (token → userinfo) and carry it on the session.
- `StateManager` — `PictureUrl` on `AuthorizedSession`.
- `ProfileImageService` (new) + DI registration.
- `UserSyncService` — pass the URL through to the image service.
- Version bumped to **1.0.7.0**.

## Docs
- README **[Profile image sync](../blob/feat/profile-image-claim/README.md#profile-image-sync)** section.
- **[Authentik: Profile Picture / Avatar](../blob/feat/profile-image-claim/examples/authentik/SETUP.md#25-optional-profile-picture--avatar)** — how to emit the `picture` claim: add a scope mapping returning `request.user.avatar` **and attach it to the provider's Selected Scopes** (creating the mapping alone is not enough).

## Verification (live Jellyfin 10.11.10 + Authentik)
Confirmed end-to-end. Authentik's default `profile` scope emits no avatar claim; after adding the scope mapping per the doc above, login logged:
```
OIDC picture claim 'picture' for user "makito": https://www.gravatar.com/avatar/8f66...
ProfileImageService: Applied OIDC profile image for user "makito"
```
and the avatar file was written to the user's config dir (`.../users/makito/profile.png`). The no-crash / never-block-login guarantees were also exercised (missing claim, userinfo fallback).

Based on top of the v1.0.6 login/RBAC fixes (#17, merged).