### PR TITLE
feat: enable SSO on native/mobile apps via Quick Connect bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 bin/
 obj/
+dist/
+repo/
 *.user
 *.suo
 .vs/

--- a/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
@@ -41,6 +41,13 @@ public class LoginButtonController : ControllerBase
             sb.AppendLine($"    btn_{p.ProviderId}.textContent = 'Sign in with {escapedName}';");
             sb.AppendLine($"    btn_{p.ProviderId}.style.cssText = 'display:block;margin:0.5em auto;padding:0.7em 1.5em;background:{escapedColor};color:#fff;text-decoration:none;border-radius:4px;font-size:1em;max-width:300px;';");
             sb.AppendLine($"    container.appendChild(btn_{p.ProviderId});");
+
+            // Quick Connect link: for signing in a native/mobile app that can't show these buttons.
+            sb.AppendLine($"    var qc_{p.ProviderId} = document.createElement('a');");
+            sb.AppendLine($"    qc_{p.ProviderId}.href = '/sso/OIDC/QuickConnect/{p.ProviderId}';");
+            sb.AppendLine($"    qc_{p.ProviderId}.textContent = 'Sign in a device with {escapedName} (Quick Connect)';");
+            sb.AppendLine($"    qc_{p.ProviderId}.style.cssText = 'display:block;margin:0.2em auto 0.8em;color:#888;text-decoration:none;font-size:0.8em;max-width:300px;';");
+            sb.AppendLine($"    container.appendChild(qc_{p.ProviderId});");
         }
 
         sb.AppendLine("    var sep = document.createElement('div');");

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -12,6 +12,7 @@ using IdentityModel.Client;
 using Jellyfin.Plugin.OIDC.Configuration;
 using Jellyfin.Plugin.OIDC.Services;
 using MediaBrowser.Controller;
+using MediaBrowser.Controller.QuickConnect;
 using MediaBrowser.Controller.Session;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -29,6 +30,7 @@ public class OidcController : ControllerBase
     private readonly StateManager _stateManager;
     private readonly UserSyncService _userSyncService;
     private readonly ISessionManager _sessionManager;
+    private readonly IQuickConnect _quickConnect;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IServerApplicationHost _appHost;
     private readonly ILogger<OidcController> _logger;
@@ -37,6 +39,7 @@ public class OidcController : ControllerBase
         StateManager stateManager,
         UserSyncService userSyncService,
         ISessionManager sessionManager,
+        IQuickConnect quickConnect,
         IHttpClientFactory httpClientFactory,
         IServerApplicationHost appHost,
         ILogger<OidcController> logger)
@@ -44,13 +47,29 @@ public class OidcController : ControllerBase
         _stateManager = stateManager;
         _userSyncService = userSyncService;
         _sessionManager = sessionManager;
+        _quickConnect = quickConnect;
         _httpClientFactory = httpClientFactory;
         _appHost = appHost;
         _logger = logger;
     }
 
     [HttpGet("Start/{providerId}")]
-    public async Task<ActionResult> Start(string providerId)
+    public Task<ActionResult> Start(string providerId)
+    {
+        return BeginAuthorizeAsync(providerId, quickConnect: false);
+    }
+
+    /// <summary>
+    /// Entry point for logging in a native/mobile app via Jellyfin Quick Connect. The user opens
+    /// this in a browser, authenticates at the IdP, then enters the code shown by their app.
+    /// </summary>
+    [HttpGet("QuickConnect/{providerId}")]
+    public Task<ActionResult> QuickConnectStart(string providerId)
+    {
+        return BeginAuthorizeAsync(providerId, quickConnect: true);
+    }
+
+    private async Task<ActionResult> BeginAuthorizeAsync(string providerId, bool quickConnect)
     {
         var provider = GetProvider(providerId);
         if (provider == null)
@@ -75,7 +94,8 @@ public class OidcController : ControllerBase
             ProviderId = providerId,
             Nonce = nonce,
             CodeVerifier = codeVerifier,
-            RedirectUri = redirectUri
+            RedirectUri = redirectUri,
+            QuickConnect = quickConnect
         };
 
         var stateKey = _stateManager.StoreState(state);
@@ -243,6 +263,11 @@ public class OidcController : ControllerBase
             Roles = roles
         });
 
+        if (oidcState.QuickConnect)
+        {
+            return Content(BuildQuickConnectHtml(sessionToken, providerId), "text/html");
+        }
+
         return Content(BuildCallbackHtml(sessionToken, providerId), "text/html");
     }
 
@@ -293,6 +318,82 @@ public class OidcController : ControllerBase
             _logger.LogError(ex, "Authentication failed for user {Username}", session.Username);
             return StatusCode(500, "Authentication failed");
         }
+    }
+
+    /// <summary>
+    /// Authorizes a pending Quick Connect request using the identity established by the OIDC login.
+    /// The user is provisioned/synced (same as web login) and then the code shown by their native
+    /// app is authorized on their behalf — no pre-existing Jellyfin session required.
+    /// </summary>
+    [HttpPost("QuickConnect/Authorize/{providerId}")]
+    public async Task<ActionResult> QuickConnectAuthorize(
+        string providerId,
+        [FromBody] QuickConnectAuthorizeRequest request)
+    {
+        if (request == null || string.IsNullOrWhiteSpace(request.Token) || string.IsNullOrWhiteSpace(request.Code))
+        {
+            return BadRequest("Missing session token or code");
+        }
+
+        // Peek (not consume) so a mistyped code can be retried without redoing the OIDC login.
+        var session = _stateManager.PeekAuthorizedSession(request.Token);
+        if (session == null)
+        {
+            return Unauthorized("Session expired. Please sign in again.");
+        }
+
+        if (!string.Equals(session.ProviderId, providerId, StringComparison.OrdinalIgnoreCase))
+        {
+            return BadRequest("Provider mismatch");
+        }
+
+        if (!_quickConnect.IsEnabled)
+        {
+            return BadRequest("Quick Connect is not enabled on this server. An administrator can enable it under Dashboard > General.");
+        }
+
+        var code = request.Code.Trim();
+
+        Guid userId;
+        try
+        {
+            userId = await _userSyncService.SyncUserAsync(
+                session.Username,
+                session.DisplayName,
+                session.Roles,
+                session.PictureUrl).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("User sync failed during Quick Connect: {Message}", ex.Message);
+            return StatusCode(403, ex.Message);
+        }
+
+        try
+        {
+            var authorized = await _quickConnect.AuthorizeRequest(userId, code).ConfigureAwait(false);
+            if (!authorized)
+            {
+                return BadRequest("Quick Connect authorization was rejected.");
+            }
+        }
+        catch (Exception ex) when (ex.GetType().Name == "ResourceNotFoundException")
+        {
+            // Unknown / expired code — keep the session valid so the user can retry.
+            return BadRequest("That code wasn't recognized. Check the code on your device and try again.");
+        }
+        catch (Exception ex) when (ex.GetType().Name == "AuthenticationException")
+        {
+            return BadRequest("Quick Connect is not active on this server.");
+        }
+
+        // Success — invalidate the one-time session so the token can't be replayed.
+        _stateManager.InvalidateAuthorizedSession(request.Token);
+        _logger.LogInformation(
+            "Quick Connect authorized for user {Username} via provider {Provider}",
+            session.Username, providerId);
+
+        return Ok(new { success = true });
     }
 
     [HttpGet("Providers")]
@@ -434,6 +535,92 @@ public class OidcController : ControllerBase
         </html>
         """;
     }
+
+    private static string BuildQuickConnectHtml(string sessionToken, string providerId)
+    {
+        return $$"""
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Quick Connect</title>
+        <style>
+            body { font-family: system-ui, -apple-system, sans-serif; background: #101010; color: #eee;
+                   display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+            .card { background: #1c1c1c; padding: 2em; border-radius: 8px; max-width: 360px; width: 90%;
+                    box-shadow: 0 4px 24px rgba(0,0,0,.5); text-align: center; }
+            h2 { margin-top: 0; }
+            p { color: #aaa; line-height: 1.5; }
+            input { width: 100%; box-sizing: border-box; font-size: 1.6em; letter-spacing: .3em;
+                    text-align: center; padding: .5em; margin: .5em 0 1em; border-radius: 4px;
+                    border: 1px solid #444; background: #111; color: #fff; }
+            button { width: 100%; padding: .8em; font-size: 1em; border: 0; border-radius: 4px;
+                     background: #00a4dc; color: #fff; cursor: pointer; }
+            button:disabled { opacity: .6; cursor: default; }
+            #msg { min-height: 1.4em; margin-top: 1em; }
+            .ok { color: #4caf50; }
+            .err { color: #f44336; }
+        </style>
+        </head>
+        <body>
+        <div class="card">
+            <h2>Quick Connect</h2>
+            <p>Enter the code shown on your device to finish signing in.</p>
+            <input id="code" inputmode="numeric" pattern="[0-9]*" maxlength="6" autocomplete="off"
+                   placeholder="000000" aria-label="Quick Connect code">
+            <button id="submit">Authorize</button>
+            <div id="msg"></div>
+        </div>
+        <script>
+        (function() {
+            const token = '{{sessionToken}}';
+            const providerId = '{{providerId}}';
+            const codeInput = document.getElementById('code');
+            const button = document.getElementById('submit');
+            const msg = document.getElementById('msg');
+
+            codeInput.focus();
+
+            function submit() {
+                const code = (codeInput.value || '').trim();
+                if (!code) { return; }
+                button.disabled = true;
+                msg.className = '';
+                msg.textContent = 'Authorizing...';
+
+                fetch('/sso/OIDC/QuickConnect/Authorize/' + encodeURIComponent(providerId), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ Token: token, Code: code })
+                })
+                .then(function(r) {
+                    return r.text().then(function(body) {
+                        if (!r.ok) { throw new Error(body || ('Error ' + r.status)); }
+                    });
+                })
+                .then(function() {
+                    msg.className = 'ok';
+                    msg.textContent = 'Approved! Return to your device — it should sign in shortly.';
+                    codeInput.disabled = true;
+                })
+                .catch(function(err) {
+                    msg.className = 'err';
+                    msg.textContent = err.message;
+                    button.disabled = false;
+                    codeInput.focus();
+                    codeInput.select();
+                });
+            }
+
+            button.addEventListener('click', submit);
+            codeInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') { submit(); } });
+        })();
+        </script>
+        </body>
+        </html>
+        """;
+    }
 }
 
 public class AuthenticateRequest
@@ -443,4 +630,10 @@ public class AuthenticateRequest
     public string? DeviceName { get; set; }
     public string? App { get; set; }
     public string? AppVersion { get; set; }
+}
+
+public class QuickConnectAuthorizeRequest
+{
+    public string Token { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
 }

--- a/Jellyfin.Plugin.OIDC/Services/StateManager.cs
+++ b/Jellyfin.Plugin.OIDC/Services/StateManager.cs
@@ -13,6 +13,13 @@ public sealed class OidcState
     public required string Nonce { get; init; }
     public required string CodeVerifier { get; init; }
     public required string RedirectUri { get; init; }
+
+    /// <summary>
+    /// When true, the callback drives Jellyfin Quick Connect (for logging in a native/mobile
+    /// app) instead of storing web-client credentials in the browser's localStorage.
+    /// </summary>
+    public bool QuickConnect { get; init; }
+
     public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
 }
 
@@ -86,6 +93,33 @@ public sealed class StateManager : IHostedService, IDisposable
         }
 
         return session;
+    }
+
+    /// <summary>
+    /// Returns the authorized session without removing it, so a caller can validate it across
+    /// multiple attempts (e.g. a mistyped Quick Connect code). Expired sessions are evicted and
+    /// return null. Invalidate explicitly with <see cref="InvalidateAuthorizedSession"/> once done.
+    /// </summary>
+    public AuthorizedSession? PeekAuthorizedSession(string token)
+    {
+        if (!_authorizedSessions.TryGetValue(token, out var session))
+        {
+            return null;
+        }
+
+        if (DateTimeOffset.UtcNow - session.CreatedAt > SessionExpiry)
+        {
+            _authorizedSessions.TryRemove(token, out _);
+            _logger.LogWarning("Authorized session expired for user {Username}", session.Username);
+            return null;
+        }
+
+        return session;
+    }
+
+    public void InvalidateAuthorizedSession(string token)
+    {
+        _authorizedSessions.TryRemove(token, out _);
     }
 
     public Task StartAsync(CancellationToken cancellationToken)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Authenticate users via any OIDC-compatible identity provider (Authentik, Keycloa
 - **Default role fallback** - assign a baseline role to users with no matching IdP roles
 - **Admin UI** - full configuration from the Jellyfin dashboard (Providers, Role Mappings, General settings)
 - **Auto-injected login buttons** - no manual branding HTML required
+- **Native/mobile app login** - sign in Android, iOS and TV apps via Jellyfin [Quick Connect](#mobile--native-apps-quick-connect)
 
 ## Installation
 
@@ -145,6 +146,44 @@ Browser                    Jellyfin Plugin              Identity Provider
 6. Plugin creates/updates the Jellyfin user and applies role-based permissions
 7. Plugin issues a Jellyfin session token and redirects to the dashboard
 
+## Mobile & native apps (Quick Connect)
+
+**The SSO login button only works in the browser-based Jellyfin Web client.** The button is
+injected into the web login page and the flow finishes by writing credentials into the browser's
+`localStorage`. Native apps (Android, iOS/Swiftfin, Android TV, etc.) render their own login
+screen and keep credentials in native storage, so they never see the button and can't consume that
+web session. This is a limitation of how Jellyfin exposes login to plugins, not a bug.
+
+To sign a native app in via SSO, the plugin bridges to Jellyfin's built-in **Quick Connect**:
+
+```
+Native app                 Browser                    Jellyfin Plugin           Identity Provider
+   |                          |                            |                          |
+   |-- tap Quick Connect      |                            |                          |
+   |   (shows 6-digit code)   |                            |                          |
+   |   ...polling...          |                            |                          |
+   |                          |-- open QuickConnect link ->|-- OIDC authorize ------->|
+   |                          |<-- login at IdP -----------|<------ callback + code --|
+   |                          |                            |-- sync user + RBAC       |
+   |                          |-- enter 6-digit code ----->|-- AuthorizeRequest ----->|
+   |<-- authenticated, signed in --------------------------|                          |
+```
+
+**Setup:**
+
+1. Enable **Quick Connect** in Jellyfin: *Admin Dashboard > General > Quick Connect > Enable*.
+2. On the mobile/native app, open the login screen and choose **Quick Connect** — it shows a
+   6-digit code and starts polling.
+3. In any browser (on the phone or another device), open
+   `https://jellyfin.example.com/sso/OIDC/QuickConnect/<providerId>`
+   (the injected login page also shows a small *"Sign in a device … (Quick Connect)"* link for this).
+4. Authenticate at your IdP as usual.
+5. Enter the 6-digit code from step 2 and click **Authorize**.
+6. The native app's poll completes and it signs in.
+
+> Quick Connect codes are short-lived. Start the flow on the app first, then enter the code
+> promptly. A mistyped code can be re-entered without repeating the IdP login.
+
 ## RBAC Details
 
 ### Role Merging
@@ -207,9 +246,11 @@ See [examples/authentik/SETUP.md](examples/authentik/SETUP.md) for a complete st
 
 | Method | Endpoint                          | Description                        |
 |--------|-----------------------------------|------------------------------------|
-| GET    | `/sso/OIDC/Start/{providerId}`    | Initiate OIDC flow                 |
+| GET    | `/sso/OIDC/Start/{providerId}`    | Initiate OIDC flow (web client)    |
 | GET    | `/sso/OIDC/Callback/{providerId}` | OIDC callback (handles code exchange) |
-| POST   | `/sso/OIDC/Auth/{providerId}`     | Complete authentication            |
+| POST   | `/sso/OIDC/Auth/{providerId}`     | Complete authentication (web client) |
+| GET    | `/sso/OIDC/QuickConnect/{providerId}` | Initiate OIDC flow for a native app via Quick Connect |
+| POST   | `/sso/OIDC/QuickConnect/Authorize/{providerId}` | Authorize a Quick Connect code after OIDC login |
 | GET    | `/sso/OIDC/Providers`             | List enabled providers             |
 | GET    | `/sso/OIDC/LoginButtons`          | JS snippet for login buttons       |
 | GET    | `/sso/OIDC/BrandingSnippet`       | HTML snippet for branding config   |


### PR DESCRIPTION
## Problem

SSO didn't work on mobile/native apps. The login flow is **web-client only**: the button is injected into the browser login page and the callback finishes by writing credentials into the browser's `localStorage`. Native apps (Android, iOS/Swiftfin, Android TV) render their own login screen and use native credential storage, so they never see the button and can't consume that web session. Architectural limitation, not a regression.

## Fix

Bridge to Jellyfin's built-in **Quick Connect**. The user authenticates at the IdP in a browser, then authorizes the 6-digit code shown by their native app — no pre-existing Jellyfin session required.

- **StateManager** — `QuickConnect` flag on `OidcState`; `Peek`/`Invalidate` helpers so a mistyped code can be retried without redoing the IdP login.
- **OidcController** — inject `IQuickConnect`; `GET /sso/OIDC/QuickConnect/{providerId}` entry point, a 6-digit code-entry callback page, and `POST /sso/OIDC/QuickConnect/Authorize/{providerId}` which syncs/provisions the user (same RBAC path as web) then calls `AuthorizeRequest(userId, code)`.
- **LoginButtonController** — per-provider Quick Connect link on the injected login page.
- **README** — documents the limitation + Quick Connect flow, diagram, setup steps, new endpoints.
- **.gitignore** — ignore build output dirs (`dist/`, `repo/`).

## User flow

1. Enable Quick Connect (Dashboard → General).
2. Tap Quick Connect in the app → get a 6-digit code.
3. Open `/sso/OIDC/QuickConnect/<provider>` in a browser, authenticate at the IdP.
4. Enter the code → app signs in.

## Testing

Compiles cleanly against Jellyfin 10.11.10 assemblies (`make docker-build`). Full end-to-end run needs a live Jellyfin + IdP + native app, not available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)