### PR TITLE
fix: honor Jellyfin base URL in generated SSO links (closes #19)

### DIFF
--- a/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
@@ -25,6 +25,10 @@ public class LoginButtonController : ControllerBase
 
         var sb = new StringBuilder();
         sb.AppendLine("(function() {");
+        // Jellyfin may run under a base path (Networking > Base URL). The web client is served
+        // under '<basePath>/web/', so derive the prefix from the login page URL. Empty when unset.
+        sb.AppendLine("  var _p = window.location.pathname.split('/web/');");
+        sb.AppendLine("  var basePath = _p.length > 1 ? _p[0] : '';");
         sb.AppendLine("  function addButtons() {");
         sb.AppendLine("    var form = document.querySelector('.manualLoginForm, #loginPage form, [data-role=\"page\"] form');");
         sb.AppendLine("    if (!form || document.getElementById('oidc-sso-buttons')) return;");
@@ -37,14 +41,14 @@ public class LoginButtonController : ControllerBase
             var escapedName = p.DisplayName.Replace("'", "\\'");
             var escapedColor = p.ButtonColor.Replace("'", "\\'");
             sb.AppendLine($"    var btn_{p.ProviderId} = document.createElement('a');");
-            sb.AppendLine($"    btn_{p.ProviderId}.href = '/sso/OIDC/Start/{p.ProviderId}';");
+            sb.AppendLine($"    btn_{p.ProviderId}.href = basePath + '/sso/OIDC/Start/{p.ProviderId}';");
             sb.AppendLine($"    btn_{p.ProviderId}.textContent = 'Sign in with {escapedName}';");
             sb.AppendLine($"    btn_{p.ProviderId}.style.cssText = 'display:block;margin:0.5em auto;padding:0.7em 1.5em;background:{escapedColor};color:#fff;text-decoration:none;border-radius:4px;font-size:1em;max-width:300px;';");
             sb.AppendLine($"    container.appendChild(btn_{p.ProviderId});");
 
             // Quick Connect link: for signing in a native/mobile app that can't show these buttons.
             sb.AppendLine($"    var qc_{p.ProviderId} = document.createElement('a');");
-            sb.AppendLine($"    qc_{p.ProviderId}.href = '/sso/OIDC/QuickConnect/{p.ProviderId}';");
+            sb.AppendLine($"    qc_{p.ProviderId}.href = basePath + '/sso/OIDC/QuickConnect/{p.ProviderId}';");
             sb.AppendLine($"    qc_{p.ProviderId}.textContent = 'Sign in a device with {escapedName} (Quick Connect)';");
             sb.AppendLine($"    qc_{p.ProviderId}.style.cssText = 'display:block;margin:0.2em auto 0.8em;color:#888;text-decoration:none;font-size:0.8em;max-width:300px;';");
             sb.AppendLine($"    container.appendChild(qc_{p.ProviderId});");
@@ -67,7 +71,10 @@ public class LoginButtonController : ControllerBase
     [HttpGet("BrandingSnippet")]
     public ActionResult GetBrandingSnippet()
     {
-        var snippet = "<script src=\"/sso/OIDC/LoginButtons\"></script>";
+        // Include Jellyfin's base path (Networking > Base URL) so the script loads under a
+        // prefixed deployment. Empty PathBase (no base URL) yields the same root-relative src.
+        var basePath = Request.PathBase.HasValue ? Request.PathBase.Value : string.Empty;
+        var snippet = $"<script src=\"{basePath}/sso/OIDC/LoginButtons\"></script>";
         return Ok(new { Html = snippet, Instructions = "Add this to Jellyfin Dashboard > General > Custom CSS/HTML, or paste the <script> tag into the Login Disclaimer field under Branding." });
     }
 }

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -413,7 +413,7 @@ public class OidcController : ControllerBase
                 p.DisplayName,
                 p.ButtonColor,
                 p.ButtonIcon,
-                StartUrl = $"{Request.Scheme}://{Request.Host}/sso/OIDC/Start/{p.ProviderId}"
+                StartUrl = $"{Request.Scheme}://{Request.Host}{Request.PathBase}/sso/OIDC/Start/{p.ProviderId}"
             });
 
         return Ok(providers);
@@ -487,10 +487,14 @@ public class OidcController : ControllerBase
             const token = '{{sessionToken}}';
             const providerId = '{{providerId}}';
 
+            // Jellyfin may run under a base path (Networking > Base URL). Derive it from the URL
+            // this callback was served at, so every link below keeps the prefix. Empty when unset.
+            const basePath = window.location.pathname.replace(/\/sso\/OIDC\/Callback\/[^/]+\/?$/i, '');
+
             const deviceId = localStorage.getItem('_deviceId2') || crypto.randomUUID();
             localStorage.setItem('_deviceId2', deviceId);
 
-            fetch('/sso/OIDC/Auth/' + providerId, {
+            fetch(basePath + '/sso/OIDC/Auth/' + providerId, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -508,7 +512,7 @@ public class OidcController : ControllerBase
             .then(function(auth) {
                 var credentials = {
                     Servers: [{
-                        ManualAddress: window.location.origin,
+                        ManualAddress: window.location.origin + basePath,
                         AccessToken: auth.AccessToken,
                         UserId: auth.User.Id,
                         IsLocalUser: true
@@ -524,7 +528,7 @@ public class OidcController : ControllerBase
                 localStorage.setItem('_jellyfin_user_' + auth.ServerId, JSON.stringify(user));
 
                 document.getElementById('status').textContent = 'Success! Redirecting...';
-                window.location.href = '/';
+                window.location.href = basePath + '/';
             })
             .catch(function(err) {
                 document.getElementById('status').textContent = 'Error: ' + err.message;
@@ -576,6 +580,8 @@ public class OidcController : ControllerBase
         (function() {
             const token = '{{sessionToken}}';
             const providerId = '{{providerId}}';
+            // Preserve Jellyfin's base path (Networking > Base URL); empty when unset.
+            const basePath = window.location.pathname.replace(/\/sso\/OIDC\/Callback\/[^/]+\/?$/i, '');
             const codeInput = document.getElementById('code');
             const button = document.getElementById('submit');
             const msg = document.getElementById('msg');
@@ -589,7 +595,7 @@ public class OidcController : ControllerBase
                 msg.className = '';
                 msg.textContent = 'Authorizing...';
 
-                fetch('/sso/OIDC/QuickConnect/Authorize/' + encodeURIComponent(providerId), {
+                fetch(basePath + '/sso/OIDC/QuickConnect/Authorize/' + encodeURIComponent(providerId), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ Token: token, Code: code })

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Go to **Admin Dashboard > General > Branding > Login disclaimer** and paste:
 </a>
 ```
 
+> The auto-injected buttons (`/sso/OIDC/LoginButtons`) and the SSO flow automatically honor a
+> Jellyfin **base URL** (Networking > Base URL). If you hand-write the `<a>` snippet above and run
+> Jellyfin under a base path, prefix the href yourself, e.g. `href="/base_url/sso/OIDC/Start/authentik"`.
+
 ## Migrating Existing Users
 
 Already have Jellyfin users you want to move to SSO without losing watch history? See [MIGRATION.md](MIGRATION.md) — username-match is automatic, but there are a few caveats around permissions overwrite and password fallback.


### PR DESCRIPTION
Closes #19.

## Problem

When Jellyfin runs under a base path (Networking > Base URL, e.g. `https://jellyfin.tld/base_url`), the plugin emitted **root-relative** URLs that dropped the prefix. The OIDC flow authenticated successfully, but the callback page then did `fetch('/sso/OIDC/Auth/<provider>')` — without `/base_url` — and 404'd. The per-provider **Server Base URL** setting only fixes the `redirect_uri`, not these client-side links, which is why it didn't help the reporter.

## Fix

Prefix every generated link with Jellyfin's base path:

- **Callback & Quick Connect pages** — derive the base path *in-browser* from the URL the page was served at (`window.location.pathname`, stripping the known `/sso/OIDC/Callback/<provider>` suffix). Correct even behind a path-rewriting reverse proxy.
- **Injected login buttons** — derive it from the web app path (everything before `/web/`).
- **`BrandingSnippet` `<script src>` and `GetProviders` `StartUrl`** — use `Request.PathBase` server-side.

## Safety

**No-op for deployments without a base URL.** When none is configured the derived prefix is an empty string, so every generated URL is byte-for-byte identical to before (`'' + '/sso/OIDC/Auth/x'` → `/sso/OIDC/Auth/x`). The prefix only appears when a base URL actually exists, and the suffix-strip is anchored so it can't over-strip.

Also folds in the Quick Connect links (added in #20) so they're base-path-correct too, and adds a README note for the hand-written button snippet.

## Testing

Compiles cleanly against Jellyfin 10.11.10 (`make docker-build`). Full base-URL runtime test needs a live prefixed Jellyfin deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)