### PR TITLE
ci: open a PR for the manifest bump instead of pushing to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -99,14 +100,27 @@ jobs:
           files: oidc-rbac.zip
           generate_release_notes: true
 
-      - name: Commit updated manifest
+      # Branch protection on main blocks the bot from pushing directly, so open a PR
+      # with the regenerated manifest. Merge it to publish the release to the catalog.
+      - name: Open manifest update PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          BRANCH="chore/manifest-${GITHUB_REF_NAME}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           cp manifest.json /tmp/manifest.json
           git fetch origin main
-          git checkout main
+          git checkout -B "$BRANCH" origin/main
           cp /tmp/manifest.json manifest.json
           git add manifest.json
-          git commit -m "Update manifest.json for ${GITHUB_REF_NAME}" || echo "No changes"
-          git push origin main
+          if git diff --cached --quiet; then
+            echo "manifest.json already up to date; nothing to do"
+            exit 0
+          fi
+          git commit -m "Update manifest.json for ${GITHUB_REF_NAME}"
+          git push -f origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "Update manifest.json for ${GITHUB_REF_NAME}" \
+            --body "Automated manifest bump for the ${GITHUB_REF_NAME} release. Merge to publish it to the plugin catalog." \
+            || echo "PR already exists for $BRANCH; branch updated in place"


### PR DESCRIPTION
## Problem

The `main` branch now requires changes via PR (added in `c343e4d`). The release workflow's final **"Commit updated manifest"** step pushed the regenerated `manifest.json` straight to `main`, which the `github-actions[bot]` can't do — so the step fails on every `v*` release (it failed on v1.0.8; I committed that manifest manually).

## Change

Replace the direct push with a branch-and-PR flow:

- Push the regenerated `manifest.json` to a per-tag branch `chore/manifest-<tag>`.
- Open a PR against `main` titled "Update manifest.json for `<tag>`".
- Add `pull-requests: write` permission.
- No-op cleanly if the manifest is already current.

The release build + GitHub release are unaffected; only the catalog-manifest publish changes.

## Note

Because branch protection also requires owner approval, the auto-opened manifest PR still needs **one click to merge** to publish to the catalog. If you'd prefer fully hands-off releases, grant `github-actions[bot]` bypass on the `main` rule instead and revert to a direct push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)