### PR TITLE
Validate ID token signature, issuer, audience and expiry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Build
+        run: dotnet build jellyfin-plugin-oidc.sln -c Release
+
+      - name: Test
+        run: dotnet test jellyfin-plugin-oidc.sln -c Release --no-build

--- a/Jellyfin.Plugin.OIDC.Tests/Jellyfin.Plugin.OIDC.Tests.csproj
+++ b/Jellyfin.Plugin.OIDC.Tests/Jellyfin.Plugin.OIDC.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Jellyfin.Plugin.OIDC.Tests/TokenValidatorTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/TokenValidatorTests.cs
@@ -1,0 +1,176 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography;
+using Jellyfin.Plugin.OIDC.Configuration;
+using Jellyfin.Plugin.OIDC.Services;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.OIDC.Tests;
+
+/// <summary>
+/// Covers what an attacker has to get past to have a token accepted. Each test forges a token
+/// that differs from a good one in exactly one way, and asserts it is rejected.
+/// </summary>
+public class TokenValidatorTests
+{
+    private const string Issuer = "https://keycloak.example.com/realms/test";
+    private const string ClientId = "jellyfin";
+
+    private static readonly RSA ProviderKey = RSA.Create(2048);
+    private static readonly RSA AttackerKey = RSA.Create(2048);
+
+    private static OidcProviderConfig Provider => new()
+    {
+        ProviderId = "keycloak",
+        Authority = Issuer,
+        ClientId = ClientId
+    };
+
+    private static OpenIdConnectConfiguration Configuration
+    {
+        get
+        {
+            var config = new OpenIdConnectConfiguration { Issuer = Issuer };
+            config.SigningKeys.Add(new RsaSecurityKey(ProviderKey) { KeyId = "provider-key" });
+            return config;
+        }
+    }
+
+    private static string CreateToken(
+        RSA? signingKey = null,
+        string issuer = Issuer,
+        string audience = ClientId,
+        DateTime? expires = null,
+        string algorithm = SecurityAlgorithms.RsaSha256)
+    {
+        var key = new RsaSecurityKey(signingKey ?? ProviderKey) { KeyId = "provider-key" };
+
+        var expiry = expires ?? DateTime.UtcNow.AddMinutes(10);
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = issuer,
+            Audience = audience,
+            // Keep nbf ahead of exp even when the caller backdates expiry to forge a stale token.
+            NotBefore = expiry.AddMinutes(-10),
+            Expires = expiry,
+            SigningCredentials = new SigningCredentials(key, algorithm),
+            Claims = new Dictionary<string, object> { ["sub"] = "user-123" }
+        };
+
+        return new JwtSecurityTokenHandler().CreateEncodedJwt(descriptor);
+    }
+
+    private static JwtSecurityToken Validate(string token, bool validateAudience = true)
+    {
+        return TokenValidator.Validate(token, Configuration, Provider, validateAudience);
+    }
+
+    [Fact]
+    public void ValidToken_IsAccepted()
+    {
+        var jwt = Validate(CreateToken());
+
+        Assert.Equal(Issuer, jwt.Issuer);
+        Assert.Equal("user-123", jwt.Claims.First(c => c.Type == "sub").Value);
+    }
+
+    [Fact]
+    public void TokenSignedByAnotherKey_IsRejected()
+    {
+        // The core of the vulnerability this validator exists to close: before it, a token
+        // signed by anybody at all was parsed and trusted.
+        Assert.ThrowsAny<SecurityTokenException>(() => Validate(CreateToken(signingKey: AttackerKey)));
+    }
+
+    [Fact]
+    public void UnsignedToken_IsRejected()
+    {
+        // "alg": "none" — header and payload with an empty signature segment.
+        var unsigned = new JwtSecurityToken(
+            issuer: Issuer,
+            audience: ClientId,
+            claims: new[] { new System.Security.Claims.Claim("sub", "user-123") },
+            notBefore: DateTime.UtcNow.AddMinutes(-1),
+            expires: DateTime.UtcNow.AddMinutes(10));
+
+        var token = new JwtSecurityTokenHandler().WriteToken(unsigned);
+
+        Assert.ThrowsAny<SecurityTokenException>(() => Validate(token));
+    }
+
+    [Fact]
+    public void TokenWithTamperedPayload_IsRejected()
+    {
+        var parts = CreateToken().Split('.');
+        var forgedPayload = Base64UrlEncoder.Encode(
+            """{"sub":"admin","iss":"https://keycloak.example.com/realms/test","aud":"jellyfin","exp":33267600000}""");
+
+        var tampered = $"{parts[0]}.{forgedPayload}.{parts[2]}";
+
+        Assert.ThrowsAny<SecurityTokenException>(() => Validate(tampered));
+    }
+
+    [Fact]
+    public void TokenForAnotherClient_IsRejected()
+    {
+        // A token the IdP legitimately minted for a different client in the same realm.
+        Assert.ThrowsAny<SecurityTokenException>(() => Validate(CreateToken(audience: "grafana")));
+    }
+
+    [Fact]
+    public void TokenFromAnotherIssuer_IsRejected()
+    {
+        Assert.ThrowsAny<SecurityTokenException>(
+            () => Validate(CreateToken(issuer: "https://evil.example.com/realms/test")));
+    }
+
+    [Fact]
+    public void ExpiredToken_IsRejected()
+    {
+        // Well past the 2-minute clock skew allowance.
+        Assert.ThrowsAny<SecurityTokenException>(
+            () => Validate(CreateToken(expires: DateTime.UtcNow.AddHours(-1))));
+    }
+
+    [Fact]
+    public void HmacSignedToken_IsRejected()
+    {
+        // Algorithm-confusion attempt: sign with HMAC so a value the attacker may know
+        // (the public key, or the client secret) becomes the signing key.
+        var secret = new SymmetricSecurityKey(new byte[32]);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            Expires = DateTime.UtcNow.AddMinutes(10),
+            SigningCredentials = new SigningCredentials(secret, SecurityAlgorithms.HmacSha256),
+            Claims = new Dictionary<string, object> { ["sub"] = "user-123" }
+        };
+
+        var token = new JwtSecurityTokenHandler().CreateEncodedJwt(descriptor);
+
+        Assert.ThrowsAny<SecurityTokenException>(() => Validate(token));
+    }
+
+    [Fact]
+    public void AccessTokenPath_SkipsAudienceButStillVerifiesSignature()
+    {
+        // Access tokens are minted for a resource server, so their audience is not ours. We
+        // still read role claims from them, so the signature must hold.
+        var forResourceServer = CreateToken(audience: "account");
+        var jwt = Validate(forResourceServer, validateAudience: false);
+        Assert.Equal(Issuer, jwt.Issuer);
+
+        Assert.ThrowsAny<SecurityTokenException>(
+            () => Validate(CreateToken(signingKey: AttackerKey, audience: "account"), validateAudience: false));
+    }
+
+    [Fact]
+    public void GarbageInput_IsRejected()
+    {
+        Assert.ThrowsAny<Exception>(() => Validate("not-a-jwt"));
+        Assert.ThrowsAny<Exception>(() => Validate(string.Empty));
+    }
+}

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -28,6 +28,7 @@ namespace Jellyfin.Plugin.OIDC.Api;
 public class OidcController : ControllerBase
 {
     private readonly StateManager _stateManager;
+    private readonly TokenValidator _tokenValidator;
     private readonly UserSyncService _userSyncService;
     private readonly ISessionManager _sessionManager;
     private readonly IQuickConnect _quickConnect;
@@ -37,6 +38,7 @@ public class OidcController : ControllerBase
 
     public OidcController(
         StateManager stateManager,
+        TokenValidator tokenValidator,
         UserSyncService userSyncService,
         ISessionManager sessionManager,
         IQuickConnect quickConnect,
@@ -45,6 +47,7 @@ public class OidcController : ControllerBase
         ILogger<OidcController> logger)
     {
         _stateManager = stateManager;
+        _tokenValidator = tokenValidator;
         _userSyncService = userSyncService;
         _sessionManager = sessionManager;
         _quickConnect = quickConnect;
@@ -167,18 +170,36 @@ public class OidcController : ControllerBase
             return BadRequest("Token exchange failed. Check plugin logs for details.");
         }
 
-        var handler = new JwtSecurityTokenHandler();
-        if (!handler.CanReadToken(tokenResponse.IdentityToken ?? tokenResponse.AccessToken))
+        // Identity comes from the ID token and nothing else. An access token is opaque to us by
+        // contract, so falling back to it when the provider returns no id_token would mean
+        // deriving a Jellyfin account from a blob we have no standing to interpret.
+        if (string.IsNullOrEmpty(tokenResponse.IdentityToken))
         {
-            return BadRequest("Could not read identity token");
+            _logger.LogError(
+                "Provider {Provider} returned no id_token. Ensure the 'openid' scope is requested and the client is an OIDC (not plain OAuth2) client.",
+                providerId);
+            return BadRequest("Identity provider did not return an ID token");
         }
 
-        var idToken = handler.ReadJwtToken(tokenResponse.IdentityToken ?? tokenResponse.AccessToken);
-
-        var nonceClaim = idToken.Claims.FirstOrDefault(c => c.Type == "nonce")?.Value;
-        if (!string.IsNullOrEmpty(oidcState.Nonce) && nonceClaim != oidcState.Nonce)
+        JwtSecurityToken idToken;
+        try
         {
-            _logger.LogWarning("Nonce mismatch in OIDC callback");
+            idToken = await _tokenValidator
+                .ValidateIdTokenAsync(provider, tokenResponse.IdentityToken, HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (TokenValidationFailedException ex)
+        {
+            _logger.LogError(ex, "ID token validation failed for provider {Provider}", providerId);
+            return BadRequest("Token validation failed. Check plugin logs for details.");
+        }
+
+        // The nonce binds this token to the authorize request we started, so it must be present
+        // and match — an ID token replayed from another login attempt is not acceptable here.
+        var nonceClaim = idToken.Claims.FirstOrDefault(c => c.Type == "nonce")?.Value;
+        if (!string.Equals(nonceClaim, oidcState.Nonce, StringComparison.Ordinal))
+        {
+            _logger.LogWarning("Nonce mismatch in OIDC callback for provider {Provider}", providerId);
             return BadRequest("Token validation failed: nonce mismatch");
         }
 
@@ -195,14 +216,18 @@ public class OidcController : ControllerBase
 
         var displayName = ClaimParser.ExtractClaim(idToken, provider.DisplayNameClaim);
 
-        // Extract roles from both the ID token and the access token, then union them.
-        // Providers differ in which token carries which claims (e.g. an admin group may
-        // land only in the access token), so relying on one token can silently drop roles.
+        // Some providers put group/role claims only in the access token (Keycloak's
+        // realm_access.roles is the common case), so we read it too — but only after verifying
+        // its signature, issuer and expiry against the same provider. Audience is not checked:
+        // an access token is minted for a resource server, not for us. It contributes claims
+        // only; identity stays with the ID token above.
+        var accessTokenClaims = await ReadAccessTokenClaimsAsync(provider, tokenResponse.AccessToken)
+            .ConfigureAwait(false);
+
         var roles = ClaimParser.ExtractRoles(idToken, provider.RoleClaim);
-        if (handler.CanReadToken(tokenResponse.AccessToken))
+        if (accessTokenClaims != null)
         {
-            var accessToken = handler.ReadJwtToken(tokenResponse.AccessToken);
-            var accessRoles = ClaimParser.ExtractRoles(accessToken, provider.RoleClaim);
+            var accessRoles = ClaimParser.ExtractRoles(accessTokenClaims, provider.RoleClaim);
             roles = roles
                 .Concat(accessRoles)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -216,10 +241,9 @@ public class OidcController : ControllerBase
         if (provider.SyncProfileImage && !string.IsNullOrWhiteSpace(provider.PictureClaim))
         {
             pictureUrl = ClaimParser.ExtractClaim(idToken, provider.PictureClaim);
-            if (string.IsNullOrEmpty(pictureUrl) && handler.CanReadToken(tokenResponse.AccessToken))
+            if (string.IsNullOrEmpty(pictureUrl) && accessTokenClaims != null)
             {
-                pictureUrl = ClaimParser.ExtractClaim(
-                    handler.ReadJwtToken(tokenResponse.AccessToken), provider.PictureClaim);
+                pictureUrl = ClaimParser.ExtractClaim(accessTokenClaims, provider.PictureClaim);
             }
 
             // Many providers (e.g. Authentik) expose the picture only via the userinfo
@@ -417,6 +441,37 @@ public class OidcController : ControllerBase
             });
 
         return Ok(providers);
+    }
+
+    /// <summary>
+    /// Returns the validated claims of the access token, or null when there are none to be had.
+    /// Opaque (non-JWT) access tokens are normal and are skipped quietly; a JWT that fails
+    /// validation is dropped with a warning rather than trusted, so a bad token costs the user
+    /// their role claims instead of granting them.
+    /// </summary>
+    private async Task<JwtSecurityToken?> ReadAccessTokenClaimsAsync(
+        OidcProviderConfig provider,
+        string? accessToken)
+    {
+        if (string.IsNullOrEmpty(accessToken) || !new JwtSecurityTokenHandler().CanReadToken(accessToken))
+        {
+            return null;
+        }
+
+        try
+        {
+            return await _tokenValidator
+                .ValidateAccessTokenForClaimsAsync(provider, accessToken, HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (TokenValidationFailedException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Access token from provider {Provider} failed validation; ignoring its claims",
+                provider.ProviderId);
+            return null;
+        }
     }
 
     private OidcProviderConfig? GetProvider(string providerId)

--- a/Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj
+++ b/Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Jellyfin.Plugin.OIDC.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.11.10">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>

--- a/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
@@ -10,6 +10,9 @@ public class ServiceRegistrator : IPluginServiceRegistrator
     {
         serviceCollection.AddSingleton<StateManager>();
         serviceCollection.AddHostedService(sp => sp.GetRequiredService<StateManager>());
+
+        // Singleton so discovery documents and JWKS stay cached across logins.
+        serviceCollection.AddSingleton<TokenValidator>();
         serviceCollection.AddScoped<RbacService>();
         serviceCollection.AddScoped<ProfileImageService>();
         serviceCollection.AddScoped<UserSyncService>();

--- a/Jellyfin.Plugin.OIDC/Services/TokenValidator.cs
+++ b/Jellyfin.Plugin.OIDC/Services/TokenValidator.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Concurrent;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.OIDC.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Jellyfin.Plugin.OIDC.Services;
+
+/// <summary>
+/// Thrown when a token from the identity provider fails cryptographic or claim validation.
+/// The message is safe to surface to the user; details are logged separately.
+/// </summary>
+public sealed class TokenValidationFailedException : Exception
+{
+    public TokenValidationFailedException(string message)
+        : base(message)
+    {
+    }
+
+    public TokenValidationFailedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Validates JWTs issued by a configured provider against the signing keys published at its
+/// JWKS endpoint.
+///
+/// The authorization-code flow fetches tokens over TLS straight from the discovered token
+/// endpoint, which is why OIDC Core 3.1.3.7 permits a client to skip signature verification.
+/// We verify anyway: the ID token drives account provisioning and the administrator flag, so
+/// TLS to the IdP should not be the only thing standing between a forged claim and an admin
+/// session. Verifying also gets us the checks that actually bite in practice — audience
+/// (a token minted for a different client in the same realm is rejected) and expiry.
+///
+/// Discovery documents and signing keys are cached per authority and refreshed automatically,
+/// so steady-state logins add no extra round trips to the IdP.
+/// </summary>
+public sealed class TokenValidator
+{
+    /// <summary>
+    /// Asymmetric algorithms only. Restricting the set keeps a provider from downgrading us to
+    /// an HMAC algorithm, where the (attacker-visible) public key or the client secret could be
+    /// used as the signing key. "none" is rejected by RequireSignedTokens regardless.
+    /// </summary>
+    private static readonly string[] AllowedAlgorithms =
+    {
+        SecurityAlgorithms.RsaSha256, SecurityAlgorithms.RsaSha384, SecurityAlgorithms.RsaSha512,
+        SecurityAlgorithms.RsaSsaPssSha256, SecurityAlgorithms.RsaSsaPssSha384, SecurityAlgorithms.RsaSsaPssSha512,
+        SecurityAlgorithms.EcdsaSha256, SecurityAlgorithms.EcdsaSha384, SecurityAlgorithms.EcdsaSha512
+    };
+
+    private readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _configManagers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<TokenValidator> _logger;
+
+    public TokenValidator(IHttpClientFactory httpClientFactory, ILogger<TokenValidator> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Fully validates an ID token: signature, issuer, audience (this client) and lifetime.
+    /// Returns the parsed token on success and throws <see cref="TokenValidationFailedException"/>
+    /// otherwise — callers must treat a throw as an authentication failure.
+    /// </summary>
+    public Task<JwtSecurityToken> ValidateIdTokenAsync(
+        OidcProviderConfig provider,
+        string idToken,
+        CancellationToken cancellationToken = default)
+    {
+        return ValidateAsync(provider, idToken, validateAudience: true, cancellationToken);
+    }
+
+    /// <summary>
+    /// Validates an access token for the purpose of reading supplementary claims (roles, picture)
+    /// that some providers place only in the access token. Signature, issuer and lifetime are
+    /// enforced; the audience is not, because an access token is minted for a resource server
+    /// rather than for this client.
+    ///
+    /// This is not an identity assertion — the ID token remains the sole source of identity.
+    /// </summary>
+    public Task<JwtSecurityToken> ValidateAccessTokenForClaimsAsync(
+        OidcProviderConfig provider,
+        string accessToken,
+        CancellationToken cancellationToken = default)
+    {
+        return ValidateAsync(provider, accessToken, validateAudience: false, cancellationToken);
+    }
+
+    private async Task<JwtSecurityToken> ValidateAsync(
+        OidcProviderConfig provider,
+        string token,
+        bool validateAudience,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new TokenValidationFailedException("No token was returned by the identity provider");
+        }
+
+        var configManager = GetConfigurationManager(provider.Authority);
+
+        OpenIdConnectConfiguration config;
+        try
+        {
+            config = await configManager.GetConfigurationAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new TokenValidationFailedException(
+                "Could not retrieve the identity provider's signing keys", ex);
+        }
+
+        try
+        {
+            return Validate(token, config, provider, validateAudience);
+        }
+        catch (SecurityTokenSignatureKeyNotFoundException)
+        {
+            // The IdP most likely rotated its signing keys since we last fetched the JWKS.
+            // Force a refresh and try once more before failing the login.
+            _logger.LogInformation(
+                "Signing key not found for provider {Provider}; refreshing JWKS and retrying",
+                provider.ProviderId);
+
+            configManager.RequestRefresh();
+
+            try
+            {
+                config = await configManager.GetConfigurationAsync(cancellationToken).ConfigureAwait(false);
+                return Validate(token, config, provider, validateAudience);
+            }
+            catch (Exception ex)
+            {
+                throw new TokenValidationFailedException(
+                    "Token signature could not be verified against the provider's signing keys", ex);
+            }
+        }
+        catch (SecurityTokenException ex)
+        {
+            throw new TokenValidationFailedException(ex.Message, ex);
+        }
+        catch (ArgumentException ex)
+        {
+            // Malformed / unreadable token.
+            throw new TokenValidationFailedException("Token could not be read", ex);
+        }
+    }
+
+    /// <summary>
+    /// The security-critical surface: everything a forged or misdirected token has to get past.
+    /// Internal so it can be exercised directly by the test suite without standing up a JWKS
+    /// endpoint — the discovery/caching around it is Microsoft.IdentityModel's code.
+    /// </summary>
+    internal static JwtSecurityToken Validate(
+        string token,
+        OpenIdConnectConfiguration config,
+        OidcProviderConfig provider,
+        bool validateAudience)
+    {
+        var parameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = config.Issuer,
+
+            ValidateAudience = validateAudience,
+            ValidAudience = validateAudience ? provider.ClientId : null,
+
+            ValidateLifetime = true,
+            RequireExpirationTime = true,
+            ClockSkew = TimeSpan.FromMinutes(2),
+
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeys = config.SigningKeys,
+            RequireSignedTokens = true,
+            ValidAlgorithms = AllowedAlgorithms
+        };
+
+        var handler = new JwtSecurityTokenHandler();
+        handler.ValidateToken(token, parameters, out var validated);
+
+        if (validated is not JwtSecurityToken jwt)
+        {
+            throw new SecurityTokenException("Validated token was not a JWT");
+        }
+
+        return jwt;
+    }
+
+    private ConfigurationManager<OpenIdConnectConfiguration> GetConfigurationManager(string authority)
+    {
+        return _configManagers.GetOrAdd(authority, key =>
+        {
+            var httpClient = _httpClientFactory.CreateClient("OidcPlugin");
+
+            // Mirror IdentityModel's discovery policy, which the rest of the plugin uses:
+            // HTTPS is required except against loopback, so local test setups keep working.
+            var documentRetriever = new HttpDocumentRetriever(httpClient)
+            {
+                RequireHttps = !IsLoopback(key)
+            };
+
+            return new ConfigurationManager<OpenIdConnectConfiguration>(
+                BuildMetadataAddress(key),
+                new OpenIdConnectConfigurationRetriever(),
+                documentRetriever);
+        });
+    }
+
+    private static string BuildMetadataAddress(string authority)
+    {
+        const string WellKnown = ".well-known/openid-configuration";
+
+        var trimmed = authority.TrimEnd('/');
+        if (trimmed.EndsWith(WellKnown, StringComparison.OrdinalIgnoreCase))
+        {
+            return trimmed;
+        }
+
+        return $"{trimmed}/{WellKnown}";
+    }
+
+    private static bool IsLoopback(string authority)
+    {
+        return Uri.TryCreate(authority, UriKind.Absolute, out var uri) && uri.IsLoopback;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -163,9 +163,37 @@ Browser                    Jellyfin Plugin              Identity Provider
 2. Plugin redirects to the IdP's authorization endpoint (with PKCE)
 3. User authenticates at the IdP
 4. IdP redirects back with an authorization code
-5. Plugin exchanges the code for tokens, extracts roles from the configured claim path
-6. Plugin creates/updates the Jellyfin user and applies role-based permissions
-7. Plugin issues a Jellyfin session token and redirects to the dashboard
+5. Plugin exchanges the code for tokens and validates the ID token
+6. Plugin extracts roles from the configured claim path
+7. Plugin creates/updates the Jellyfin user and applies role-based permissions
+8. Plugin issues a Jellyfin session token and redirects to the dashboard
+
+### Token validation
+
+The ID token is verified against the signing keys published at the provider's JWKS endpoint
+before any of its claims are used:
+
+| Check | Enforced |
+| --- | --- |
+| Signature (RSA/ECDSA only — `none` and HMAC rejected) | Yes |
+| Issuer matches the discovery document | Yes |
+| Audience matches the configured Client ID | Yes |
+| Expiry (2 minute clock skew allowance) | Yes |
+| `nonce` matches the authorize request | Yes |
+
+Discovery documents and signing keys are cached per provider and refreshed automatically, so
+logins do not add round trips to the IdP. Key rotation is handled: a token signed by an unknown
+key triggers one JWKS refresh and retry before the login fails.
+
+A provider that returns no `id_token` is rejected. If you see this, the client is likely
+configured as a plain OAuth2 client, or the `openid` scope is missing from the Scopes field.
+
+Access tokens are also read, since some providers place group/role claims only there (Keycloak's
+`realm_access.roles` is the common case). They are signature-, issuer- and expiry-checked the same
+way; only the audience check is skipped, because an access token is minted for a resource server
+rather than for Jellyfin. An access token that fails validation is ignored rather than trusted —
+the affected user loses their role claims rather than gaining any. Identity itself always comes
+from the ID token.
 
 ## Mobile & native apps (Quick Connect)
 
@@ -294,6 +322,12 @@ make build
 make docker-build
 ```
 
+### Test
+
+```bash
+dotnet test jellyfin-plugin-oidc.sln
+```
+
 ### Package (installable zip)
 
 ```bash
@@ -325,10 +359,14 @@ Jellyfin.Plugin.OIDC/
     OidcAuthProvider.cs          # Blocks password login for SSO users
   Services/
     StateManager.cs              # Thread-safe OIDC state with TTL
+    TokenValidator.cs            # JWKS-backed ID/access token validation
     ClaimParser.cs               # JWT claim extraction (nested paths)
     RbacService.cs               # Role-to-permission mapping engine
     UserSyncService.cs           # User provisioning and sync
+    ProfileImageService.cs       # Avatar sync from the picture claim
     ServiceRegistrator.cs        # DI registration
+Jellyfin.Plugin.OIDC.Tests/
+  TokenValidatorTests.cs         # Token forgery / misdirection rejection tests
 ```
 
 ## License

--- a/jellyfin-plugin-oidc.sln
+++ b/jellyfin-plugin-oidc.sln
@@ -1,19 +1,48 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.OIDC", "Jellyfin.Plugin.OIDC\Jellyfin.Plugin.OIDC.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.OIDC.Tests", "Jellyfin.Plugin.OIDC.Tests\Jellyfin.Plugin.OIDC.Tests.csproj", "{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x86.Build.0 = Debug|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x86.Build.0 = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|x64.Build.0 = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|x86.Build.0 = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|x64.ActiveCfg = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|x64.Build.0 = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|x86.ActiveCfg = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Human note!

Hey, thanks for maintaining/creating this plugin - I am working on integrating it into my own setup, just raising a few PRs - feel free to close, merge, whatever. 

- Sam

## Problem

The OIDC callback parses tokens with `JwtSecurityTokenHandler.ReadJwtToken`, which only
base64-decodes them. There is no signature check, and no issuer, audience or expiry check
anywhere in the plugin. `Microsoft.IdentityModel.Protocols.OpenIdConnect` is already a declared
dependency but is never called.

The authorization-code flow does fetch tokens over TLS straight from the discovered token
endpoint, which is why OIDC Core §3.1.3.7 permits a client to skip signature verification. But
claims from these tokens drive account provisioning and `policy.IsAdministrator`, so TLS to the
IdP is currently the only thing standing between a forged claim and an administrator session.
The checks that bite in practice are missing too:

- a token minted for a **different client in the same realm** is accepted
- an **expired** token is accepted
- roles are read from the access token, which is not validated at all

## Change

Adds `TokenValidator`, which verifies tokens against the signing keys published at the
provider's JWKS endpoint:

| Check | Enforced |
| --- | --- |
| Signature, restricted to RSA/ECDSA | yes |
| Issuer matches the discovery document | yes |
| Audience matches the configured Client ID | yes (ID token) |
| Expiry, 2 min clock skew | yes |
| `nonce` present and matching | yes |

Algorithms are restricted to RSA/ECDSA so a provider cannot downgrade the exchange to an HMAC
algorithm keyed on a value an attacker may know; `none` is rejected by `RequireSignedTokens`.

Discovery documents and signing keys are cached per authority and refreshed automatically, so
steady-state logins add no round trips. Key rotation is handled: a token signed by an unknown
key triggers one JWKS refresh and retry before the login fails.

Also in this PR:

- **Drops the `IdentityToken ?? AccessToken` fallback.** An access token is opaque to the client
  by contract, so deriving an account from one was unsound. A provider returning no `id_token`
  is now a hard failure, logged with the likely cause (missing `openid` scope, or the client is
  configured as plain OAuth2 rather than OIDC).
- **Validates the access token before reading role/picture claims from it.** Audience is
  deliberately *not* checked there, since an access token is minted for a resource server rather
  than for us, and providers commonly put group claims only in it (Keycloak's
  `realm_access.roles`). One that fails validation is ignored rather than trusted, so a bad
  token costs a user their role claims rather than granting any. Identity comes from the ID
  token alone.
- **Requires the `nonce` claim to be present**, rather than skipping the check when it is absent.

## Tests

Adds the first test project in the repo, plus a CI workflow running build and test on PRs.

Ten tests, each forging a token that differs from a good one in exactly one way: foreign signing
key, unsigned (`alg: none`), tampered payload, wrong audience, wrong issuer, expired, HMAC
algorithm confusion, the access-token path, and the happy path.

`TokenValidator.Validate` is `internal` with `InternalsVisibleTo` so the tests exercise the real
`TokenValidationParameters` without standing up a JWKS endpoint — the discovery and caching
around it is Microsoft.IdentityModel's code.

## Compatibility

No configuration changes. Correctly-behaving providers are unaffected. Two upgrade risks worth
calling out:

1. A deployment whose provider returns no `id_token` (plain OAuth2 client) will now fail to log
   in rather than silently authenticating off the access token. Happy to put this behind a flag
   if you would prefer.
2. A provider whose access token is a JWT signed by a *different* issuer than its ID token would
   lose its role claims. I have not found one that does this, but flagging it.

Tested against Keycloak 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
