### PR TITLE
Key accounts on the subject claim, and deprovision on role loss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Build
+        run: dotnet build jellyfin-plugin-oidc.sln -c Release
+
+      - name: Test
+        run: dotnet test jellyfin-plugin-oidc.sln -c Release --no-build

--- a/Jellyfin.Plugin.OIDC.Tests/Jellyfin.Plugin.OIDC.Tests.csproj
+++ b/Jellyfin.Plugin.OIDC.Tests/Jellyfin.Plugin.OIDC.Tests.csproj
@@ -9,8 +9,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The plugin excludes these at runtime because the Jellyfin host supplies them. Tests have
+         no host, so reference them normally to get the assemblies copied to the test output. -->
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.10" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.OIDC.Tests/Jellyfin.Plugin.OIDC.Tests.csproj
+++ b/Jellyfin.Plugin.OIDC.Tests/Jellyfin.Plugin.OIDC.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Jellyfin.Plugin.OIDC.Tests/RbacServiceTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/RbacServiceTests.cs
@@ -1,0 +1,133 @@
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.OIDC.Configuration;
+using Jellyfin.Plugin.OIDC.Services;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Users;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.OIDC.Tests;
+
+/// <summary>
+/// Covers deprovisioning: what happens to an account whose IdP roles stop justifying the
+/// permissions it holds.
+/// </summary>
+public class RbacServiceTests
+{
+    private readonly Mock<IUserManager> _userManager = new();
+    private readonly Mock<ILibraryManager> _libraryManager = new();
+    private readonly InMemoryConfigurationStore _store = new();
+
+    private UserPolicy? _savedPolicy;
+
+    private RbacService CreateService(User user, UserPolicy currentPolicy)
+    {
+        _userManager.Setup(m => m.GetUserById(user.Id)).Returns(user);
+        _userManager.Setup(m => m.GetUserDto(user, It.IsAny<string>()))
+            .Returns(new UserDto { Policy = currentPolicy });
+        _userManager.Setup(m => m.UpdatePolicyAsync(user.Id, It.IsAny<UserPolicy>()))
+            .Callback((Guid _, UserPolicy p) => _savedPolicy = p)
+            .Returns(Task.CompletedTask);
+
+        return new RbacService(
+            _userManager.Object,
+            _libraryManager.Object,
+            _store,
+            NullLogger<RbacService>.Instance);
+    }
+
+    private static User NewUser(string name = "chowder") => new(
+        name,
+        "Jellyfin.Plugin.OIDC.Auth.OidcAuthProvider",
+        "Emby.Server.Implementations.Library.DefaultPasswordResetProvider");
+
+    [Fact]
+    public async Task NoMatchingRole_RevokesAdministrator()
+    {
+        // The bug this replaced: the method returned early, so an admin who lost their role at
+        // the IdP stayed an admin in Jellyfin forever.
+        var user = NewUser();
+        var service = CreateService(user, new UserPolicy { IsAdministrator = true });
+
+        await service.ApplyRoleMappingsAsync(user.Id, new[] { "some-unmapped-role" });
+
+        Assert.NotNull(_savedPolicy);
+        Assert.False(_savedPolicy!.IsAdministrator);
+    }
+
+    [Fact]
+    public async Task NoMatchingRole_DoesNotLockTheUserOut()
+    {
+        // Only admin is revoked. A mapping typo should not disable people's media access.
+        var user = NewUser();
+        var service = CreateService(
+            user,
+            new UserPolicy { IsAdministrator = true, IsDisabled = false, EnableMediaPlayback = true });
+
+        await service.ApplyRoleMappingsAsync(user.Id, new[] { "some-unmapped-role" });
+
+        Assert.False(_savedPolicy!.IsDisabled);
+        Assert.True(_savedPolicy.EnableMediaPlayback);
+    }
+
+    [Fact]
+    public async Task MatchingAdminRole_GrantsAdministratorAndAllLibraries()
+    {
+        var user = NewUser();
+        _store.Configuration.RoleMappings.Add(new RoleMapping
+        {
+            RoleName = "jellyfin-admin",
+            IsAdmin = true
+        });
+
+        var service = CreateService(user, new UserPolicy { IsAdministrator = false });
+
+        await service.ApplyRoleMappingsAsync(user.Id, new[] { "jellyfin-admin" });
+
+        Assert.True(_savedPolicy!.IsAdministrator);
+        Assert.True(_savedPolicy.EnableAllFolders);
+    }
+
+    [Fact]
+    public async Task MatchingRole_ReEnablesAPreviouslyDisabledAccount()
+    {
+        var user = NewUser();
+        _store.Configuration.RoleMappings.Add(new RoleMapping { RoleName = "friend" });
+
+        var service = CreateService(user, new UserPolicy { IsDisabled = true });
+
+        await service.ApplyRoleMappingsAsync(user.Id, new[] { "friend" });
+
+        Assert.False(_savedPolicy!.IsDisabled);
+    }
+
+    [Fact]
+    public async Task RoleMatchingIsCaseInsensitive()
+    {
+        // IdPs differ on the casing of group names; a case difference should not silently
+        // demote someone.
+        var user = NewUser();
+        _store.Configuration.RoleMappings.Add(new RoleMapping
+        {
+            RoleName = "Jellyfin-Admin",
+            IsAdmin = true
+        });
+
+        var service = CreateService(user, new UserPolicy());
+
+        await service.ApplyRoleMappingsAsync(user.Id, new[] { "jellyfin-admin" });
+
+        Assert.True(_savedPolicy!.IsAdministrator);
+    }
+
+    private sealed class InMemoryConfigurationStore : IConfigurationStore
+    {
+        public PluginConfiguration Configuration { get; private set; } = new();
+
+        public PluginConfiguration Get() => Configuration;
+
+        public void Save(PluginConfiguration configuration) => Configuration = configuration;
+    }
+}

--- a/Jellyfin.Plugin.OIDC.Tests/TokenValidatorTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/TokenValidatorTests.cs
@@ -1,0 +1,176 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography;
+using Jellyfin.Plugin.OIDC.Configuration;
+using Jellyfin.Plugin.OIDC.Services;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.OIDC.Tests;
+
+/// <summary>
+/// Covers what an attacker has to get past to have a token accepted. Each test forges a token
+/// that differs from a good one in exactly one way, and asserts it is rejected.
+/// </summary>
+public class TokenValidatorTests
+{
+    private const string Issuer = "https://keycloak.example.com/realms/test";
+    private const string ClientId = "jellyfin";
+
+    private static readonly RSA ProviderKey = RSA.Create(2048);
+    private static readonly RSA AttackerKey = RSA.Create(2048);
+
+    private static OidcProviderConfig Provider => new()
+    {
+        ProviderId = "keycloak",
+        Authority = Issuer,
+        ClientId = ClientId
+    };
+
+    private static OpenIdConnectConfiguration Configuration
+    {
+        get
+        {
+            var config = new OpenIdConnectConfiguration { Issuer = Issuer };
+            config.SigningKeys.Add(new RsaSecurityKey(ProviderKey) { KeyId = "provider-key" });
+            return config;
+        }
+    }
+
+    private static string CreateToken(
+        RSA? signingKey = null,
+        string issuer = Issuer,
+        string audience = ClientId,
+        DateTime? expires = null,
+        string algorithm = SecurityAlgorithms.RsaSha256)
+    {
+        var key = new RsaSecurityKey(signingKey ?? ProviderKey) { KeyId = "provider-key" };
+
+        var expiry = expires ?? DateTime.UtcNow.AddMinutes(10);
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = issuer,
+            Audience = audience,
+            // Keep nbf ahead of exp even when the caller backdates expiry to forge a stale token.
+            NotBefore = expiry.AddMinutes(-10),
+            Expires = expiry,
+            SigningCredentials = new SigningCredentials(key, algorithm),
+            Claims = new Dictionary<string, object> { ["sub"] = "user-123" }
+        };
+
+        return new JwtSecurityTokenHandler().CreateEncodedJwt(descriptor);
+    }
+
+    private static JwtSecurityToken Validate(string token, bool validateAudience = true)
+    {
+        return TokenValidator.Validate(token, Configuration, Provider, validateAudience);
+    }
+
+    [Fact]
+    public void ValidToken_IsAccepted()
+    {
+        var jwt = Validate(CreateToken());
+
+        Assert.Equal(Issuer, jwt.Issuer);
+        Assert.Equal("user-123", jwt.Claims.First(c => c.Type == "sub").Value);
+    }
+
+    [Fact]
+    public void TokenSignedByAnotherKey_IsRejected()
+    {
+        // The core of the vulnerability this validator exists to close: before it, a token
+        // signed by anybody at all was parsed and trusted.
+        Assert.ThrowsAny<SecurityTokenException>(() => Validate(CreateToken(signingKey: AttackerKey)));
+    }
+
+    [Fact]
+    public void UnsignedToken_IsRejected()
+    {
+        // "alg": "none" — header and payload with an empty signature segment.
+        var unsigned = new JwtSecurityToken(
+            issuer: Issuer,
+            audience: ClientId,
+            claims: new[] { new System.Security.Claims.Claim("sub", "user-123") },
+            notBefore: DateTime.UtcNow.AddMinutes(-1),
+            expires: DateTime.UtcNow.AddMinutes(10));
+
+        var token = new JwtSecurityTokenHandler().WriteToken(unsigned);
+
+        Assert.ThrowsAny<SecurityTokenException>(() => Validate(token));
+    }
+
+    [Fact]
+    public void TokenWithTamperedPayload_IsRejected()
+    {
+        var parts = CreateToken().Split('.');
+        var forgedPayload = Base64UrlEncoder.Encode(
+            """{"sub":"admin","iss":"https://keycloak.example.com/realms/test","aud":"jellyfin","exp":33267600000}""");
+
+        var tampered = $"{parts[0]}.{forgedPayload}.{parts[2]}";
+
+        Assert.ThrowsAny<SecurityTokenException>(() => Validate(tampered));
+    }
+
+    [Fact]
+    public void TokenForAnotherClient_IsRejected()
+    {
+        // A token the IdP legitimately minted for a different client in the same realm.
+        Assert.ThrowsAny<SecurityTokenException>(() => Validate(CreateToken(audience: "grafana")));
+    }
+
+    [Fact]
+    public void TokenFromAnotherIssuer_IsRejected()
+    {
+        Assert.ThrowsAny<SecurityTokenException>(
+            () => Validate(CreateToken(issuer: "https://evil.example.com/realms/test")));
+    }
+
+    [Fact]
+    public void ExpiredToken_IsRejected()
+    {
+        // Well past the 2-minute clock skew allowance.
+        Assert.ThrowsAny<SecurityTokenException>(
+            () => Validate(CreateToken(expires: DateTime.UtcNow.AddHours(-1))));
+    }
+
+    [Fact]
+    public void HmacSignedToken_IsRejected()
+    {
+        // Algorithm-confusion attempt: sign with HMAC so a value the attacker may know
+        // (the public key, or the client secret) becomes the signing key.
+        var secret = new SymmetricSecurityKey(new byte[32]);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            Expires = DateTime.UtcNow.AddMinutes(10),
+            SigningCredentials = new SigningCredentials(secret, SecurityAlgorithms.HmacSha256),
+            Claims = new Dictionary<string, object> { ["sub"] = "user-123" }
+        };
+
+        var token = new JwtSecurityTokenHandler().CreateEncodedJwt(descriptor);
+
+        Assert.ThrowsAny<SecurityTokenException>(() => Validate(token));
+    }
+
+    [Fact]
+    public void AccessTokenPath_SkipsAudienceButStillVerifiesSignature()
+    {
+        // Access tokens are minted for a resource server, so their audience is not ours. We
+        // still read role claims from them, so the signature must hold.
+        var forResourceServer = CreateToken(audience: "account");
+        var jwt = Validate(forResourceServer, validateAudience: false);
+        Assert.Equal(Issuer, jwt.Issuer);
+
+        Assert.ThrowsAny<SecurityTokenException>(
+            () => Validate(CreateToken(signingKey: AttackerKey, audience: "account"), validateAudience: false));
+    }
+
+    [Fact]
+    public void GarbageInput_IsRejected()
+    {
+        Assert.ThrowsAny<Exception>(() => Validate("not-a-jwt"));
+        Assert.ThrowsAny<Exception>(() => Validate(string.Empty));
+    }
+}

--- a/Jellyfin.Plugin.OIDC.Tests/UserResolverTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/UserResolverTests.cs
@@ -1,0 +1,282 @@
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.OIDC.Configuration;
+using Jellyfin.Plugin.OIDC.Services;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Users;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.OIDC.Tests;
+
+/// <summary>
+/// Covers which Jellyfin account an incoming identity ends up on. The failure mode these guard
+/// against is one person's account being handed to another, so the refusals matter as much as
+/// the successes.
+/// </summary>
+public class UserResolverTests
+{
+    private const string Issuer = "https://auth.example.com/realms/goblin";
+
+    private readonly Mock<IUserManager> _userManager = new(MockBehavior.Strict);
+    private readonly InMemoryConfigurationStore _store = new();
+    private readonly List<User> _users = new();
+
+    private UserResolver CreateResolver()
+    {
+        _userManager
+            .Setup(m => m.GetUserById(It.IsAny<Guid>()))
+            .Returns((Guid id) => _users.FirstOrDefault(u => u.Id == id));
+
+        _userManager
+            .Setup(m => m.GetUserByName(It.IsAny<string>()))
+            .Returns((string name) =>
+                _users.FirstOrDefault(u => string.Equals(u.Username, name, StringComparison.OrdinalIgnoreCase)));
+
+        var linkStore = new UserLinkStore(_store, NullLogger<UserLinkStore>.Instance);
+        return new UserResolver(_userManager.Object, linkStore, _store, NullLogger<UserResolver>.Instance);
+    }
+
+    private User AddUser(string username, bool isAdministrator = false, string? authProvider = null)
+    {
+        var user = new User(
+            username,
+            authProvider ?? "Emby.Server.Implementations.Library.DefaultAuthenticationProvider",
+            "Emby.Server.Implementations.Library.DefaultPasswordResetProvider");
+
+        _users.Add(user);
+
+        _userManager
+            .Setup(m => m.GetUserDto(user, It.IsAny<string>()))
+            .Returns(new UserDto { Policy = new UserPolicy { IsAdministrator = isAdministrator } });
+
+        return user;
+    }
+
+    private void SetupCreate(string username)
+    {
+        _userManager
+            .Setup(m => m.CreateUserAsync(username))
+            .ReturnsAsync(() => AddUser(username));
+
+        _userManager
+            .Setup(m => m.ChangePassword(It.IsAny<Guid>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    private static OidcIdentity Identity(string username, string subject = "sub-alice")
+    {
+        return new OidcIdentity
+        {
+            ProviderId = "keycloak",
+            Issuer = Issuer,
+            Subject = subject,
+            Username = username
+        };
+    }
+
+    [Fact]
+    public async Task FirstLogin_AdoptsExistingAccountAndRecordsLink()
+    {
+        var existing = AddUser("alice");
+        var resolver = CreateResolver();
+
+        var (user, isNew) = await resolver.ResolveUserAsync(Identity("alice"));
+
+        Assert.Same(existing, user);
+        Assert.False(isNew);
+
+        var link = Assert.Single(_store.Configuration.UserLinks);
+        Assert.Equal("sub-alice", link.Subject);
+        Assert.Equal(existing.Id, link.UserId);
+        Assert.True(link.AdoptedExistingAccount);
+    }
+
+    [Fact]
+    public async Task RenamedAtIdp_StaysOnTheLinkedAccount()
+    {
+        // The reason to key on `sub`: a user renamed in Keycloak must keep their watch history,
+        // not silently get a second empty account.
+        var existing = AddUser("alice");
+        var resolver = CreateResolver();
+
+        await resolver.ResolveUserAsync(Identity("alice"));
+        var (user, isNew) = await resolver.ResolveUserAsync(Identity("alice.newname"));
+
+        Assert.Same(existing, user);
+        Assert.False(isNew);
+        Assert.Single(_store.Configuration.UserLinks);
+    }
+
+    [Fact]
+    public async Task UsernameReassignedToDifferentPerson_DoesNotInheritTheAccount()
+    {
+        // The converse: someone taking over a freed-up username at the IdP is a different
+        // subject, so they must not land on the original holder's account.
+        var original = AddUser("alice");
+        SetupCreate("alice");
+        var resolver = CreateResolver();
+
+        await resolver.ResolveUserAsync(Identity("alice", "sub-alice"));
+
+        // Second identity, same username, different subject. The account is already linked.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => resolver.ResolveUserAsync(Identity("alice", "sub-impostor")));
+
+        Assert.Contains("already linked", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(_store.Configuration.UserLinks);
+        Assert.Equal(original.Id, _store.Configuration.UserLinks[0].UserId);
+    }
+
+    [Fact]
+    public async Task AdminAccount_IsNeverAdoptedByUsername()
+    {
+        AddUser("sam", isAdministrator: true);
+        var resolver = CreateResolver();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => resolver.ResolveUserAsync(Identity("sam", "sub-sam")));
+
+        Assert.Contains("administrator", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(_store.Configuration.UserLinks);
+    }
+
+    [Fact]
+    public async Task AdminAccount_IsUsableViaAnExplicitLink()
+    {
+        // The supported way to put an OIDC identity on an admin account: seed the link, which
+        // resolves by subject and never goes near the username fallback.
+        var admin = AddUser("sam", isAdministrator: true);
+        _store.Configuration.UserLinks.Add(new UserLink
+        {
+            ProviderId = "keycloak",
+            Issuer = Issuer,
+            Subject = "sub-sam",
+            UserId = admin.Id,
+            LinkedUsername = "sam"
+        });
+        var resolver = CreateResolver();
+
+        var (user, isNew) = await resolver.ResolveUserAsync(Identity("sam", "sub-sam"));
+
+        Assert.Same(admin, user);
+        Assert.False(isNew);
+    }
+
+    [Fact]
+    public async Task StrictMode_RefusesToAdoptAnUnlinkedAccount()
+    {
+        AddUser("alice");
+        _store.Configuration.LinkingMode = UserLinkingMode.Strict;
+        var resolver = CreateResolver();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => resolver.ResolveUserAsync(Identity("alice")));
+
+        Assert.Contains("not linked", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(_store.Configuration.UserLinks);
+    }
+
+    [Fact]
+    public async Task StrictMode_StillHonoursAnExistingLink()
+    {
+        // Switching to Strict after migration must not lock out everyone already linked.
+        var existing = AddUser("alice");
+        var resolver = CreateResolver();
+        await resolver.ResolveUserAsync(Identity("alice"));
+
+        _store.Configuration.LinkingMode = UserLinkingMode.Strict;
+
+        var (user, isNew) = await resolver.ResolveUserAsync(Identity("alice"));
+
+        Assert.Same(existing, user);
+        Assert.False(isNew);
+    }
+
+    [Fact]
+    public async Task AccountManagedByAnotherAuthProvider_IsNotAdopted()
+    {
+        AddUser("bob", authProvider: "Some.Other.Sso.Provider");
+        var resolver = CreateResolver();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => resolver.ResolveUserAsync(Identity("bob", "sub-bob")));
+
+        Assert.Contains("another authentication provider", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UnknownUser_IsCreatedAndLinked()
+    {
+        SetupCreate("carol");
+        var resolver = CreateResolver();
+
+        var (user, isNew) = await resolver.ResolveUserAsync(Identity("carol", "sub-carol"));
+
+        Assert.True(isNew);
+        Assert.Equal("carol", user.Username);
+
+        var link = Assert.Single(_store.Configuration.UserLinks);
+        Assert.False(link.AdoptedExistingAccount);
+        Assert.Equal(user.Id, link.UserId);
+    }
+
+    [Fact]
+    public async Task UnknownUser_IsRejectedWhenAutoCreationDisabled()
+    {
+        _store.Configuration.AutoCreateUsers = false;
+        var resolver = CreateResolver();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => resolver.ResolveUserAsync(Identity("dave", "sub-dave")));
+
+        Assert.Empty(_store.Configuration.UserLinks);
+    }
+
+    [Fact]
+    public async Task DeletedAccount_IsRelinkedRatherThanFailingForever()
+    {
+        var original = AddUser("erin");
+        var resolver = CreateResolver();
+        await resolver.ResolveUserAsync(Identity("erin", "sub-erin"));
+
+        // Admin deletes the account in Jellyfin; the link now dangles.
+        _users.Remove(original);
+        SetupCreate("erin");
+
+        var (user, isNew) = await resolver.ResolveUserAsync(Identity("erin", "sub-erin"));
+
+        Assert.True(isNew);
+        Assert.NotEqual(original.Id, user.Id);
+
+        var link = Assert.Single(_store.Configuration.UserLinks);
+        Assert.Equal(user.Id, link.UserId);
+    }
+
+    [Fact]
+    public async Task SubjectComparison_IsCaseSensitive()
+    {
+        // `sub` is opaque; two subjects differing only in case are not the same principal.
+        var existing = AddUser("frank");
+        SetupCreate("frank");
+        var resolver = CreateResolver();
+
+        await resolver.ResolveUserAsync(Identity("frank", "AbC"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => resolver.ResolveUserAsync(Identity("frank", "abc")));
+
+        Assert.Contains("already linked", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(existing.Id, _store.Configuration.UserLinks[0].UserId);
+    }
+
+    private sealed class InMemoryConfigurationStore : IConfigurationStore
+    {
+        public PluginConfiguration Configuration { get; private set; } = new();
+
+        public PluginConfiguration Get() => Configuration;
+
+        public void Save(PluginConfiguration configuration) => Configuration = configuration;
+    }
+}

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -203,15 +203,19 @@ public class OidcController : ControllerBase
             return BadRequest("Token validation failed: nonce mismatch");
         }
 
+        // The subject is what the Jellyfin account is keyed on, so it is mandatory. It is always
+        // present in a spec-compliant ID token; the validation above would have rejected one
+        // that was not signed by the provider.
+        var subject = ClaimParser.ExtractClaim(idToken, "sub");
+        if (string.IsNullOrEmpty(subject))
+        {
+            return BadRequest("Identity provider did not return a subject claim");
+        }
+
         var username = ClaimParser.ExtractClaim(idToken, provider.UsernameClaim);
         if (string.IsNullOrEmpty(username))
         {
-            username = ClaimParser.ExtractClaim(idToken, "sub");
-        }
-
-        if (string.IsNullOrEmpty(username))
-        {
-            return BadRequest("Could not determine username from token");
+            username = subject;
         }
 
         var displayName = ClaimParser.ExtractClaim(idToken, provider.DisplayNameClaim);
@@ -275,12 +279,15 @@ public class OidcController : ControllerBase
                 string.IsNullOrEmpty(pictureUrl) ? "not found in token or userinfo" : pictureUrl);
         }
 
-        _logger.LogInformation("OIDC auth successful: user={Username}, roles=[{Roles}], provider={Provider}",
-            username, string.Join(", ", roles), providerId);
+        _logger.LogInformation(
+            "OIDC auth successful: subject={Subject}, user={Username}, roles=[{Roles}], provider={Provider}",
+            subject, username, string.Join(", ", roles), providerId);
 
         var sessionToken = _stateManager.StoreAuthorizedSession(new AuthorizedSession
         {
             ProviderId = providerId,
+            Issuer = idToken.Issuer,
+            Subject = subject,
             Username = username,
             DisplayName = displayName,
             PictureUrl = string.IsNullOrEmpty(pictureUrl) ? null : pictureUrl,
@@ -314,8 +321,7 @@ public class OidcController : ControllerBase
         try
         {
             var userId = await _userSyncService.SyncUserAsync(
-                session.Username,
-                session.DisplayName,
+                ToIdentity(session),
                 session.Roles,
                 session.PictureUrl).ConfigureAwait(false);
 
@@ -382,8 +388,7 @@ public class OidcController : ControllerBase
         try
         {
             userId = await _userSyncService.SyncUserAsync(
-                session.Username,
-                session.DisplayName,
+                ToIdentity(session),
                 session.Roles,
                 session.PictureUrl).ConfigureAwait(false);
         }
@@ -472,6 +477,18 @@ public class OidcController : ControllerBase
                 provider.ProviderId);
             return null;
         }
+    }
+
+    private static OidcIdentity ToIdentity(AuthorizedSession session)
+    {
+        return new OidcIdentity
+        {
+            ProviderId = session.ProviderId,
+            Issuer = session.Issuer,
+            Subject = session.Subject,
+            Username = session.Username,
+            DisplayName = session.DisplayName
+        };
     }
 
     private OidcProviderConfig? GetProvider(string providerId)

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -28,6 +28,7 @@ namespace Jellyfin.Plugin.OIDC.Api;
 public class OidcController : ControllerBase
 {
     private readonly StateManager _stateManager;
+    private readonly TokenValidator _tokenValidator;
     private readonly UserSyncService _userSyncService;
     private readonly ISessionManager _sessionManager;
     private readonly IQuickConnect _quickConnect;
@@ -37,6 +38,7 @@ public class OidcController : ControllerBase
 
     public OidcController(
         StateManager stateManager,
+        TokenValidator tokenValidator,
         UserSyncService userSyncService,
         ISessionManager sessionManager,
         IQuickConnect quickConnect,
@@ -45,6 +47,7 @@ public class OidcController : ControllerBase
         ILogger<OidcController> logger)
     {
         _stateManager = stateManager;
+        _tokenValidator = tokenValidator;
         _userSyncService = userSyncService;
         _sessionManager = sessionManager;
         _quickConnect = quickConnect;
@@ -167,18 +170,36 @@ public class OidcController : ControllerBase
             return BadRequest("Token exchange failed. Check plugin logs for details.");
         }
 
-        var handler = new JwtSecurityTokenHandler();
-        if (!handler.CanReadToken(tokenResponse.IdentityToken ?? tokenResponse.AccessToken))
+        // Identity comes from the ID token and nothing else. An access token is opaque to us by
+        // contract, so falling back to it when the provider returns no id_token would mean
+        // deriving a Jellyfin account from a blob we have no standing to interpret.
+        if (string.IsNullOrEmpty(tokenResponse.IdentityToken))
         {
-            return BadRequest("Could not read identity token");
+            _logger.LogError(
+                "Provider {Provider} returned no id_token. Ensure the 'openid' scope is requested and the client is an OIDC (not plain OAuth2) client.",
+                providerId);
+            return BadRequest("Identity provider did not return an ID token");
         }
 
-        var idToken = handler.ReadJwtToken(tokenResponse.IdentityToken ?? tokenResponse.AccessToken);
-
-        var nonceClaim = idToken.Claims.FirstOrDefault(c => c.Type == "nonce")?.Value;
-        if (!string.IsNullOrEmpty(oidcState.Nonce) && nonceClaim != oidcState.Nonce)
+        JwtSecurityToken idToken;
+        try
         {
-            _logger.LogWarning("Nonce mismatch in OIDC callback");
+            idToken = await _tokenValidator
+                .ValidateIdTokenAsync(provider, tokenResponse.IdentityToken, HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (TokenValidationFailedException ex)
+        {
+            _logger.LogError(ex, "ID token validation failed for provider {Provider}", providerId);
+            return BadRequest("Token validation failed. Check plugin logs for details.");
+        }
+
+        // The nonce binds this token to the authorize request we started, so it must be present
+        // and match — an ID token replayed from another login attempt is not acceptable here.
+        var nonceClaim = idToken.Claims.FirstOrDefault(c => c.Type == "nonce")?.Value;
+        if (!string.Equals(nonceClaim, oidcState.Nonce, StringComparison.Ordinal))
+        {
+            _logger.LogWarning("Nonce mismatch in OIDC callback for provider {Provider}", providerId);
             return BadRequest("Token validation failed: nonce mismatch");
         }
 
@@ -195,14 +216,18 @@ public class OidcController : ControllerBase
 
         var displayName = ClaimParser.ExtractClaim(idToken, provider.DisplayNameClaim);
 
-        // Extract roles from both the ID token and the access token, then union them.
-        // Providers differ in which token carries which claims (e.g. an admin group may
-        // land only in the access token), so relying on one token can silently drop roles.
+        // Some providers put group/role claims only in the access token (Keycloak's
+        // realm_access.roles is the common case), so we read it too — but only after verifying
+        // its signature, issuer and expiry against the same provider. Audience is not checked:
+        // an access token is minted for a resource server, not for us. It contributes claims
+        // only; identity stays with the ID token above.
+        var accessTokenClaims = await ReadAccessTokenClaimsAsync(provider, tokenResponse.AccessToken)
+            .ConfigureAwait(false);
+
         var roles = ClaimParser.ExtractRoles(idToken, provider.RoleClaim);
-        if (handler.CanReadToken(tokenResponse.AccessToken))
+        if (accessTokenClaims != null)
         {
-            var accessToken = handler.ReadJwtToken(tokenResponse.AccessToken);
-            var accessRoles = ClaimParser.ExtractRoles(accessToken, provider.RoleClaim);
+            var accessRoles = ClaimParser.ExtractRoles(accessTokenClaims, provider.RoleClaim);
             roles = roles
                 .Concat(accessRoles)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -216,10 +241,9 @@ public class OidcController : ControllerBase
         if (provider.SyncProfileImage && !string.IsNullOrWhiteSpace(provider.PictureClaim))
         {
             pictureUrl = ClaimParser.ExtractClaim(idToken, provider.PictureClaim);
-            if (string.IsNullOrEmpty(pictureUrl) && handler.CanReadToken(tokenResponse.AccessToken))
+            if (string.IsNullOrEmpty(pictureUrl) && accessTokenClaims != null)
             {
-                pictureUrl = ClaimParser.ExtractClaim(
-                    handler.ReadJwtToken(tokenResponse.AccessToken), provider.PictureClaim);
+                pictureUrl = ClaimParser.ExtractClaim(accessTokenClaims, provider.PictureClaim);
             }
 
             // Many providers (e.g. Authentik) expose the picture only via the userinfo
@@ -417,6 +441,37 @@ public class OidcController : ControllerBase
             });
 
         return Ok(providers);
+    }
+
+    /// <summary>
+    /// Returns the validated claims of the access token, or null when there are none to be had.
+    /// Opaque (non-JWT) access tokens are normal and are skipped quietly; a JWT that fails
+    /// validation is dropped with a warning rather than trusted, so a bad token costs the user
+    /// their role claims instead of granting them.
+    /// </summary>
+    private async Task<JwtSecurityToken?> ReadAccessTokenClaimsAsync(
+        OidcProviderConfig provider,
+        string? accessToken)
+    {
+        if (string.IsNullOrEmpty(accessToken) || !new JwtSecurityTokenHandler().CanReadToken(accessToken))
+        {
+            return null;
+        }
+
+        try
+        {
+            return await _tokenValidator
+                .ValidateAccessTokenForClaimsAsync(provider, accessToken, HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (TokenValidationFailedException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Access token from provider {Provider} failed validation; ignoring its claims",
+                provider.ProviderId);
+            return null;
+        }
     }
 
     private OidcProviderConfig? GetProvider(string providerId)

--- a/Jellyfin.Plugin.OIDC/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.OIDC/Configuration/PluginConfiguration.cs
@@ -1,7 +1,29 @@
+using System;
 using System.Collections.Generic;
 using MediaBrowser.Model.Plugins;
 
 namespace Jellyfin.Plugin.OIDC.Configuration;
+
+/// <summary>
+/// How an incoming OIDC identity is matched to a Jellyfin account on its first login, before
+/// any link exists. Once linked, the identity is resolved by subject and this no longer applies.
+/// </summary>
+public enum UserLinkingMode
+{
+    /// <summary>
+    /// Adopt an existing Jellyfin account whose username matches the incoming username claim.
+    /// This is the migration path for a server with established local accounts: the account and
+    /// all its watch state are preserved, and the link is recorded so the match happens once.
+    /// </summary>
+    MigrateByUsername = 0,
+
+    /// <summary>
+    /// Never adopt an unlinked account. An identity with no link is a new user, subject to
+    /// <see cref="PluginConfiguration.AutoCreateUsers"/>. Use once migration is complete: it
+    /// closes the window in which an IdP account can claim a local account by name.
+    /// </summary>
+    Strict = 1
+}
 
 public class PluginConfiguration : BasePluginConfiguration
 {
@@ -14,6 +36,46 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool AutoCreateUsers { get; set; } = true;
 
     public string DefaultRoleName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// How unlinked identities are matched to existing accounts. See <see cref="UserLinkingMode"/>.
+    /// </summary>
+    public UserLinkingMode LinkingMode { get; set; } = UserLinkingMode.MigrateByUsername;
+
+    /// <summary>
+    /// Identity-to-account links, keyed on the IdP's issuer and subject. The subject is the only
+    /// identifier an IdP promises is stable and unique — usernames and email addresses can both
+    /// be changed and reassigned — so once a link exists it takes precedence over any name match.
+    /// </summary>
+    public List<UserLink> UserLinks { get; set; } = new();
+}
+
+/// <summary>
+/// A resolved binding between an external identity and a Jellyfin account.
+/// </summary>
+public class UserLink
+{
+    public string ProviderId { get; set; } = string.Empty;
+
+    /// <summary>Issuer that asserted the subject; scopes the subject to one IdP.</summary>
+    public string Issuer { get; set; } = string.Empty;
+
+    /// <summary>The `sub` claim — stable and unique within the issuer.</summary>
+    public string Subject { get; set; } = string.Empty;
+
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Username at the time of linking. Informational only — it is not used for matching, and
+    /// goes stale if the account is renamed on either side. Kept so the admin UI and logs can
+    /// show a human-readable link.
+    /// </summary>
+    public string LinkedUsername { get; set; } = string.Empty;
+
+    /// <summary>Whether the link was made by adopting a pre-existing account, or by creating one.</summary>
+    public bool AdoptedExistingAccount { get; set; }
+
+    public DateTime LinkedAt { get; set; }
 }
 
 public class OidcProviderConfig

--- a/Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj
+++ b/Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Jellyfin.Plugin.OIDC.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.11.10">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>

--- a/Jellyfin.Plugin.OIDC/Services/ConfigurationStore.cs
+++ b/Jellyfin.Plugin.OIDC/Services/ConfigurationStore.cs
@@ -1,0 +1,34 @@
+using Jellyfin.Plugin.OIDC.Configuration;
+
+namespace Jellyfin.Plugin.OIDC.Services;
+
+/// <summary>
+/// Read/write access to the plugin configuration.
+///
+/// The rest of the plugin reaches for the <see cref="OidcPlugin.Instance"/> singleton directly,
+/// which is fine for read-only config lookups but makes the account-linking logic — which both
+/// reads and writes — impossible to exercise without a running Jellyfin host. This interface
+/// exists so that logic can be tested against an in-memory configuration.
+/// </summary>
+public interface IConfigurationStore
+{
+    PluginConfiguration Get();
+
+    void Save(PluginConfiguration configuration);
+}
+
+/// <summary>
+/// The real store, backed by Jellyfin's plugin configuration file.
+/// </summary>
+public sealed class PluginConfigurationStore : IConfigurationStore
+{
+    public PluginConfiguration Get()
+    {
+        return OidcPlugin.Instance?.Configuration ?? new PluginConfiguration();
+    }
+
+    public void Save(PluginConfiguration configuration)
+    {
+        OidcPlugin.Instance?.UpdateConfiguration(configuration);
+    }
+}

--- a/Jellyfin.Plugin.OIDC/Services/RbacService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/RbacService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.OIDC.Configuration;
 using MediaBrowser.Controller.Library;
@@ -15,25 +16,24 @@ public class RbacService
 {
     private readonly IUserManager _userManager;
     private readonly ILibraryManager _libraryManager;
+    private readonly IConfigurationStore _configurationStore;
     private readonly ILogger<RbacService> _logger;
 
     public RbacService(
         IUserManager userManager,
         ILibraryManager libraryManager,
+        IConfigurationStore configurationStore,
         ILogger<RbacService> logger)
     {
         _userManager = userManager;
         _libraryManager = libraryManager;
+        _configurationStore = configurationStore;
         _logger = logger;
     }
 
     public async Task ApplyRoleMappingsAsync(Guid userId, string[] userRoles)
     {
-        var config = OidcPlugin.Instance?.Configuration;
-        if (config == null)
-        {
-            return;
-        }
+        var config = _configurationStore.Get();
 
         var user = _userManager.GetUserById(userId);
         if (user == null)
@@ -47,9 +47,6 @@ public class RbacService
         // and silently drops Permission/Preference changes (admin flag, enabled folders, ...),
         // which would leave users on Jellyfin's permissive default (access to all libraries).
         var policy = _userManager.GetUserDto(user).Policy;
-
-        // OIDC-authenticated users are always enabled on login.
-        policy.IsDisabled = false;
 
         var matchedMappings = config.RoleMappings
             .Where(m => userRoles.Contains(m.RoleName, StringComparer.OrdinalIgnoreCase))
@@ -68,11 +65,24 @@ public class RbacService
 
         if (matchedMappings.Count == 0)
         {
-            _logger.LogInformation("No role mappings matched for user {Username} with roles [{Roles}]; leaving permissions unchanged",
+            // Nothing vouches for this user any more. Returning here — which is what the code
+            // used to do — would leave the policy untouched, so a user who lost their admin role
+            // at the IdP would stay an administrator in Jellyfin indefinitely. Revoking admin is
+            // the part that has to happen; the rest of their permissions are left alone so a
+            // misconfigured mapping locks nobody out of their media.
+            _logger.LogWarning(
+                "No role mappings matched for user {Username} with roles [{Roles}]; revoking administrator",
                 user.Username, string.Join(", ", userRoles));
+
+            policy.IsAdministrator = false;
             await _userManager.UpdatePolicyAsync(userId, policy).ConfigureAwait(false);
             return;
         }
+
+        // A mapping matched, so the IdP still vouches for this user: an account disabled in the
+        // Jellyfin UI is re-enabled here. Note this is only reached on a match — an unmapped
+        // login above leaves IsDisabled alone, so disabling someone is not undone by SSO.
+        policy.IsDisabled = false;
 
         var merged = MergeMappings(matchedMappings);
 

--- a/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
@@ -10,6 +10,9 @@ public class ServiceRegistrator : IPluginServiceRegistrator
     {
         serviceCollection.AddSingleton<StateManager>();
         serviceCollection.AddHostedService(sp => sp.GetRequiredService<StateManager>());
+
+        // Singleton so discovery documents and JWKS stay cached across logins.
+        serviceCollection.AddSingleton<TokenValidator>();
         serviceCollection.AddScoped<RbacService>();
         serviceCollection.AddScoped<ProfileImageService>();
         serviceCollection.AddScoped<UserSyncService>();

--- a/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
@@ -13,6 +13,13 @@ public class ServiceRegistrator : IPluginServiceRegistrator
 
         // Singleton so discovery documents and JWKS stay cached across logins.
         serviceCollection.AddSingleton<TokenValidator>();
+
+        serviceCollection.AddSingleton<IConfigurationStore, PluginConfigurationStore>();
+
+        // Singleton so its write lock actually serialises concurrent link writes.
+        serviceCollection.AddSingleton<UserLinkStore>();
+
+        serviceCollection.AddScoped<UserResolver>();
         serviceCollection.AddScoped<RbacService>();
         serviceCollection.AddScoped<ProfileImageService>();
         serviceCollection.AddScoped<UserSyncService>();

--- a/Jellyfin.Plugin.OIDC/Services/StateManager.cs
+++ b/Jellyfin.Plugin.OIDC/Services/StateManager.cs
@@ -26,6 +26,13 @@ public sealed class OidcState
 public sealed class AuthorizedSession
 {
     public required string ProviderId { get; init; }
+
+    /// <summary>Issuer of the ID token this session was established from.</summary>
+    public required string Issuer { get; init; }
+
+    /// <summary>The `sub` claim — what the Jellyfin account is actually keyed on.</summary>
+    public required string Subject { get; init; }
+
     public required string Username { get; init; }
     public string? DisplayName { get; init; }
     public string? PictureUrl { get; init; }

--- a/Jellyfin.Plugin.OIDC/Services/TokenValidator.cs
+++ b/Jellyfin.Plugin.OIDC/Services/TokenValidator.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Concurrent;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.OIDC.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Jellyfin.Plugin.OIDC.Services;
+
+/// <summary>
+/// Thrown when a token from the identity provider fails cryptographic or claim validation.
+/// The message is safe to surface to the user; details are logged separately.
+/// </summary>
+public sealed class TokenValidationFailedException : Exception
+{
+    public TokenValidationFailedException(string message)
+        : base(message)
+    {
+    }
+
+    public TokenValidationFailedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Validates JWTs issued by a configured provider against the signing keys published at its
+/// JWKS endpoint.
+///
+/// The authorization-code flow fetches tokens over TLS straight from the discovered token
+/// endpoint, which is why OIDC Core 3.1.3.7 permits a client to skip signature verification.
+/// We verify anyway: the ID token drives account provisioning and the administrator flag, so
+/// TLS to the IdP should not be the only thing standing between a forged claim and an admin
+/// session. Verifying also gets us the checks that actually bite in practice — audience
+/// (a token minted for a different client in the same realm is rejected) and expiry.
+///
+/// Discovery documents and signing keys are cached per authority and refreshed automatically,
+/// so steady-state logins add no extra round trips to the IdP.
+/// </summary>
+public sealed class TokenValidator
+{
+    /// <summary>
+    /// Asymmetric algorithms only. Restricting the set keeps a provider from downgrading us to
+    /// an HMAC algorithm, where the (attacker-visible) public key or the client secret could be
+    /// used as the signing key. "none" is rejected by RequireSignedTokens regardless.
+    /// </summary>
+    private static readonly string[] AllowedAlgorithms =
+    {
+        SecurityAlgorithms.RsaSha256, SecurityAlgorithms.RsaSha384, SecurityAlgorithms.RsaSha512,
+        SecurityAlgorithms.RsaSsaPssSha256, SecurityAlgorithms.RsaSsaPssSha384, SecurityAlgorithms.RsaSsaPssSha512,
+        SecurityAlgorithms.EcdsaSha256, SecurityAlgorithms.EcdsaSha384, SecurityAlgorithms.EcdsaSha512
+    };
+
+    private readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _configManagers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<TokenValidator> _logger;
+
+    public TokenValidator(IHttpClientFactory httpClientFactory, ILogger<TokenValidator> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Fully validates an ID token: signature, issuer, audience (this client) and lifetime.
+    /// Returns the parsed token on success and throws <see cref="TokenValidationFailedException"/>
+    /// otherwise — callers must treat a throw as an authentication failure.
+    /// </summary>
+    public Task<JwtSecurityToken> ValidateIdTokenAsync(
+        OidcProviderConfig provider,
+        string idToken,
+        CancellationToken cancellationToken = default)
+    {
+        return ValidateAsync(provider, idToken, validateAudience: true, cancellationToken);
+    }
+
+    /// <summary>
+    /// Validates an access token for the purpose of reading supplementary claims (roles, picture)
+    /// that some providers place only in the access token. Signature, issuer and lifetime are
+    /// enforced; the audience is not, because an access token is minted for a resource server
+    /// rather than for this client.
+    ///
+    /// This is not an identity assertion — the ID token remains the sole source of identity.
+    /// </summary>
+    public Task<JwtSecurityToken> ValidateAccessTokenForClaimsAsync(
+        OidcProviderConfig provider,
+        string accessToken,
+        CancellationToken cancellationToken = default)
+    {
+        return ValidateAsync(provider, accessToken, validateAudience: false, cancellationToken);
+    }
+
+    private async Task<JwtSecurityToken> ValidateAsync(
+        OidcProviderConfig provider,
+        string token,
+        bool validateAudience,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new TokenValidationFailedException("No token was returned by the identity provider");
+        }
+
+        var configManager = GetConfigurationManager(provider.Authority);
+
+        OpenIdConnectConfiguration config;
+        try
+        {
+            config = await configManager.GetConfigurationAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new TokenValidationFailedException(
+                "Could not retrieve the identity provider's signing keys", ex);
+        }
+
+        try
+        {
+            return Validate(token, config, provider, validateAudience);
+        }
+        catch (SecurityTokenSignatureKeyNotFoundException)
+        {
+            // The IdP most likely rotated its signing keys since we last fetched the JWKS.
+            // Force a refresh and try once more before failing the login.
+            _logger.LogInformation(
+                "Signing key not found for provider {Provider}; refreshing JWKS and retrying",
+                provider.ProviderId);
+
+            configManager.RequestRefresh();
+
+            try
+            {
+                config = await configManager.GetConfigurationAsync(cancellationToken).ConfigureAwait(false);
+                return Validate(token, config, provider, validateAudience);
+            }
+            catch (Exception ex)
+            {
+                throw new TokenValidationFailedException(
+                    "Token signature could not be verified against the provider's signing keys", ex);
+            }
+        }
+        catch (SecurityTokenException ex)
+        {
+            throw new TokenValidationFailedException(ex.Message, ex);
+        }
+        catch (ArgumentException ex)
+        {
+            // Malformed / unreadable token.
+            throw new TokenValidationFailedException("Token could not be read", ex);
+        }
+    }
+
+    /// <summary>
+    /// The security-critical surface: everything a forged or misdirected token has to get past.
+    /// Internal so it can be exercised directly by the test suite without standing up a JWKS
+    /// endpoint — the discovery/caching around it is Microsoft.IdentityModel's code.
+    /// </summary>
+    internal static JwtSecurityToken Validate(
+        string token,
+        OpenIdConnectConfiguration config,
+        OidcProviderConfig provider,
+        bool validateAudience)
+    {
+        var parameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = config.Issuer,
+
+            ValidateAudience = validateAudience,
+            ValidAudience = validateAudience ? provider.ClientId : null,
+
+            ValidateLifetime = true,
+            RequireExpirationTime = true,
+            ClockSkew = TimeSpan.FromMinutes(2),
+
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeys = config.SigningKeys,
+            RequireSignedTokens = true,
+            ValidAlgorithms = AllowedAlgorithms
+        };
+
+        var handler = new JwtSecurityTokenHandler();
+        handler.ValidateToken(token, parameters, out var validated);
+
+        if (validated is not JwtSecurityToken jwt)
+        {
+            throw new SecurityTokenException("Validated token was not a JWT");
+        }
+
+        return jwt;
+    }
+
+    private ConfigurationManager<OpenIdConnectConfiguration> GetConfigurationManager(string authority)
+    {
+        return _configManagers.GetOrAdd(authority, key =>
+        {
+            var httpClient = _httpClientFactory.CreateClient("OidcPlugin");
+
+            // Mirror IdentityModel's discovery policy, which the rest of the plugin uses:
+            // HTTPS is required except against loopback, so local test setups keep working.
+            var documentRetriever = new HttpDocumentRetriever(httpClient)
+            {
+                RequireHttps = !IsLoopback(key)
+            };
+
+            return new ConfigurationManager<OpenIdConnectConfiguration>(
+                BuildMetadataAddress(key),
+                new OpenIdConnectConfigurationRetriever(),
+                documentRetriever);
+        });
+    }
+
+    private static string BuildMetadataAddress(string authority)
+    {
+        const string WellKnown = ".well-known/openid-configuration";
+
+        var trimmed = authority.TrimEnd('/');
+        if (trimmed.EndsWith(WellKnown, StringComparison.OrdinalIgnoreCase))
+        {
+            return trimmed;
+        }
+
+        return $"{trimmed}/{WellKnown}";
+    }
+
+    private static bool IsLoopback(string authority)
+    {
+        return Uri.TryCreate(authority, UriKind.Absolute, out var uri) && uri.IsLoopback;
+    }
+}

--- a/Jellyfin.Plugin.OIDC/Services/UserLinkStore.cs
+++ b/Jellyfin.Plugin.OIDC/Services/UserLinkStore.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.OIDC.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.OIDC.Services;
+
+/// <summary>
+/// Stores the bindings between external identities (issuer + subject) and Jellyfin accounts.
+///
+/// Links live in the plugin configuration, which Jellyfin persists as XML. Logins can overlap,
+/// and the configuration object is read-modify-write, so every mutation here is serialised
+/// behind a lock — two first-time logins arriving together must not lose one another's link.
+/// </summary>
+public sealed class UserLinkStore
+{
+    private readonly object _writeLock = new();
+    private readonly IConfigurationStore _configurationStore;
+    private readonly ILogger<UserLinkStore> _logger;
+
+    public UserLinkStore(IConfigurationStore configurationStore, ILogger<UserLinkStore> logger)
+    {
+        _configurationStore = configurationStore;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the account linked to this identity, or null when the identity is unlinked.
+    /// </summary>
+    public UserLink? Find(string issuer, string subject)
+    {
+        if (string.IsNullOrEmpty(issuer) || string.IsNullOrEmpty(subject))
+        {
+            return null;
+        }
+
+        return _configurationStore.Get().UserLinks
+            .FirstOrDefault(l => Matches(l, issuer, subject));
+    }
+
+    /// <summary>
+    /// Returns the link held on a Jellyfin account, or null when the account is unlinked.
+    /// Used to refuse adopting an account that already belongs to a different identity.
+    /// </summary>
+    public UserLink? FindByUserId(Guid userId)
+    {
+        return _configurationStore.Get().UserLinks.FirstOrDefault(l => l.UserId == userId);
+    }
+
+    /// <summary>
+    /// Records a link, replacing any existing link for the same identity. Idempotent: re-linking
+    /// an identity to the account it already points at rewrites nothing and skips the save.
+    /// </summary>
+    public void Link(UserLink link)
+    {
+        lock (_writeLock)
+        {
+            var config = _configurationStore.Get();
+            var existing = config.UserLinks.FirstOrDefault(l => Matches(l, link.Issuer, link.Subject));
+
+            if (existing != null)
+            {
+                if (existing.UserId == link.UserId)
+                {
+                    return;
+                }
+
+                _logger.LogWarning(
+                    "Re-pointing OIDC link for subject {Subject} from user {OldUserId} to {NewUserId}",
+                    link.Subject, existing.UserId, link.UserId);
+
+                config.UserLinks.Remove(existing);
+            }
+
+            config.UserLinks.Add(link);
+            _configurationStore.Save(config);
+
+            _logger.LogInformation(
+                "Linked OIDC identity {Subject} ({Issuer}) to Jellyfin user {Username} [{UserId}]{Adopted}",
+                link.Subject, link.Issuer, link.LinkedUsername, link.UserId,
+                link.AdoptedExistingAccount ? " by adopting an existing account" : string.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Drops links pointing at accounts that no longer exist, so a deleted-and-recreated user
+    /// does not resolve to a dangling GUID forever. Returns the number of links removed.
+    /// </summary>
+    public int PruneLinks(Func<Guid, bool> userExists)
+    {
+        lock (_writeLock)
+        {
+            var config = _configurationStore.Get();
+            var stale = config.UserLinks.Where(l => !userExists(l.UserId)).ToList();
+            if (stale.Count == 0)
+            {
+                return 0;
+            }
+
+            foreach (var link in stale)
+            {
+                _logger.LogInformation(
+                    "Removing stale OIDC link for subject {Subject}: user {UserId} no longer exists",
+                    link.Subject, link.UserId);
+                config.UserLinks.Remove(link);
+            }
+
+            _configurationStore.Save(config);
+            return stale.Count;
+        }
+    }
+
+    private static bool Matches(UserLink link, string issuer, string subject)
+    {
+        // Subject comparison is ordinal and case-sensitive: `sub` is an opaque identifier, and
+        // nothing licenses us to treat two subjects differing in case as the same principal.
+        return string.Equals(link.Subject, subject, StringComparison.Ordinal)
+               && string.Equals(link.Issuer, issuer, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Jellyfin.Plugin.OIDC/Services/UserResolver.cs
+++ b/Jellyfin.Plugin.OIDC/Services/UserResolver.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.OIDC.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.OIDC.Services;
+
+/// <summary>
+/// Decides which Jellyfin account an authenticated external identity belongs to, creating or
+/// adopting one on a first login. Kept separate from <see cref="UserSyncService"/>, which applies
+/// state to an account once this has decided which account that is.
+/// </summary>
+public class UserResolver
+{
+    private readonly IUserManager _userManager;
+    private readonly UserLinkStore _linkStore;
+    private readonly IConfigurationStore _configurationStore;
+    private readonly ILogger<UserResolver> _logger;
+
+    public UserResolver(
+        IUserManager userManager,
+        UserLinkStore linkStore,
+        IConfigurationStore configurationStore,
+        ILogger<UserResolver> logger)
+    {
+        _userManager = userManager;
+        _linkStore = linkStore;
+        _configurationStore = configurationStore;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Maps an external identity to a Jellyfin account.
+    ///
+    /// Resolution is by subject, never by name, once a link exists — the `sub` claim is the only
+    /// identifier the IdP promises is stable and unique, so a user renamed at the IdP keeps their
+    /// account and a username reassigned to someone else does not hand over the previous holder's.
+    ///
+    /// A first login has no link and must fall back to a name match to be useful on a server with
+    /// established accounts. That fallback is the one moment an IdP account can claim a local
+    /// account, so it is guarded and recorded, and it happens at most once per identity.
+    /// </summary>
+    public async Task<(User User, bool IsNew)> ResolveUserAsync(OidcIdentity identity)
+    {
+        var config = _configurationStore.Get();
+
+        var link = _linkStore.Find(identity.Issuer, identity.Subject);
+        if (link != null)
+        {
+            var linkedUser = _userManager.GetUserById(link.UserId);
+            if (linkedUser != null)
+            {
+                return (linkedUser, false);
+            }
+
+            // The account was deleted in Jellyfin. Drop the dangling link and fall through, so
+            // the identity is treated as new rather than failing every login from here on.
+            _logger.LogWarning(
+                "OIDC link for subject {Subject} points at user {UserId}, which no longer exists; relinking",
+                identity.Subject, link.UserId);
+            _linkStore.PruneLinks(id => _userManager.GetUserById(id) != null);
+        }
+
+        var existingByName = _userManager.GetUserByName(identity.Username);
+        if (existingByName != null)
+        {
+            return (AdoptExistingUser(config, identity, existingByName), false);
+        }
+
+        if (!config.AutoCreateUsers)
+        {
+            throw new InvalidOperationException(
+                $"User '{identity.Username}' does not exist and auto-creation is disabled");
+        }
+
+        var user = await _userManager.CreateUserAsync(identity.Username).ConfigureAwait(false);
+
+        // Jellyfin requires a password on the row; this account authenticates via OIDC, so set an
+        // unguessable one rather than leaving it empty.
+        var randomPassword = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        await _userManager.ChangePassword(user.Id, randomPassword).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Created Jellyfin user {Username} for OIDC subject {Subject}",
+            identity.Username, identity.Subject);
+
+        RecordLink(identity, user.Id, adopted: false);
+
+        return (user, true);
+    }
+
+    /// <summary>
+    /// Binds an identity to a pre-existing local account of the same name, if the configuration
+    /// permits it. Every refusal here is a case where proceeding would hand one person's account
+    /// to another, so they fail the login rather than guessing.
+    /// </summary>
+    private User AdoptExistingUser(PluginConfiguration config, OidcIdentity identity, User existing)
+    {
+        if (config.LinkingMode != UserLinkingMode.MigrateByUsername)
+        {
+            throw new InvalidOperationException(
+                $"A Jellyfin account named '{identity.Username}' already exists but is not linked to this "
+                + "identity, and account linking by username is disabled. Link it deliberately, or rename one of the accounts.");
+        }
+
+        var conflicting = _linkStore.FindByUserId(existing.Id);
+        if (conflicting != null)
+        {
+            throw new InvalidOperationException(
+                $"Jellyfin account '{identity.Username}' is already linked to a different identity "
+                + $"(subject {conflicting.Subject}). Refusing to transfer it.");
+        }
+
+        // An account carrying an SSO provider from a different plugin is not ours to claim.
+        var provider = existing.AuthenticationProviderId;
+        if (!string.IsNullOrEmpty(provider)
+            && !provider.Contains("DefaultAuthenticationProvider", StringComparison.Ordinal)
+            && !provider.Equals(typeof(Auth.OidcAuthProvider).FullName, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Jellyfin account '{identity.Username}' is managed by another authentication provider "
+                + $"({provider}). Refusing to adopt it.");
+        }
+
+        // An administrator account is the worst thing a username collision can hand over, and on
+        // an established server it is among the likeliest to share a name with an IdP account.
+        // There is no toggle for this: link it deliberately instead.
+        if (IsAdministrator(existing))
+        {
+            throw new InvalidOperationException(
+                $"Jellyfin account '{identity.Username}' is an administrator. Administrator accounts are "
+                + "never adopted by username — add an explicit link for this identity instead.");
+        }
+
+        _logger.LogWarning(
+            "Adopting existing Jellyfin account {Username} [{UserId}] for OIDC subject {Subject}. "
+            + "Its watch history and preferences are preserved; its permissions are now governed by role mappings.",
+            existing.Username, existing.Id, identity.Subject);
+
+        RecordLink(identity, existing.Id, adopted: true);
+
+        return existing;
+    }
+
+    private void RecordLink(OidcIdentity identity, Guid userId, bool adopted)
+    {
+        _linkStore.Link(new UserLink
+        {
+            ProviderId = identity.ProviderId,
+            Issuer = identity.Issuer,
+            Subject = identity.Subject,
+            UserId = userId,
+            LinkedUsername = identity.Username,
+            AdoptedExistingAccount = adopted,
+            LinkedAt = DateTime.UtcNow
+        });
+    }
+
+    private bool IsAdministrator(User user)
+    {
+        return _userManager.GetUserDto(user).Policy?.IsAdministrator ?? false;
+    }
+}

--- a/Jellyfin.Plugin.OIDC/Services/UserSyncService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/UserSyncService.cs
@@ -2,51 +2,59 @@ using System;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.OIDC.Configuration;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.OIDC.Services;
 
+/// <summary>
+/// An authenticated identity as asserted by the provider's ID token.
+/// </summary>
+public sealed class OidcIdentity
+{
+    public required string ProviderId { get; init; }
+
+    /// <summary>The `iss` claim — scopes <see cref="Subject"/> to one identity provider.</summary>
+    public required string Issuer { get; init; }
+
+    /// <summary>The `sub` claim — stable and unique within the issuer.</summary>
+    public required string Subject { get; init; }
+
+    /// <summary>
+    /// From the configured username claim. Used to name a newly created account and to find an
+    /// existing one on a first login; never used to identify an already-linked account.
+    /// </summary>
+    public required string Username { get; init; }
+
+    public string? DisplayName { get; init; }
+}
+
 public class UserSyncService
 {
     private readonly IUserManager _userManager;
+    private readonly UserResolver _userResolver;
     private readonly RbacService _rbacService;
     private readonly ProfileImageService _profileImageService;
     private readonly ILogger<UserSyncService> _logger;
 
     public UserSyncService(
         IUserManager userManager,
+        UserResolver userResolver,
         RbacService rbacService,
         ProfileImageService profileImageService,
         ILogger<UserSyncService> logger)
     {
         _userManager = userManager;
+        _userResolver = userResolver;
         _rbacService = rbacService;
         _profileImageService = profileImageService;
         _logger = logger;
     }
 
-    public async Task<Guid> SyncUserAsync(string username, string? displayName, string[] roles, string? pictureUrl)
+    public async Task<Guid> SyncUserAsync(OidcIdentity identity, string[] roles, string? pictureUrl)
     {
-        var user = _userManager.GetUserByName(username);
-        var isNewUser = user == null;
-
-        if (user == null)
-        {
-            var config = OidcPlugin.Instance?.Configuration;
-            if (config?.AutoCreateUsers != true)
-            {
-                throw new InvalidOperationException(
-                    $"User '{username}' does not exist and auto-creation is disabled");
-            }
-
-            user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
-
-            var randomPassword = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
-            await _userManager.ChangePassword(user.Id, randomPassword).ConfigureAwait(false);
-
-            _logger.LogInformation("Created new OIDC user: {Username}", username);
-        }
+        var (user, isNewUser) = await _userResolver.ResolveUserAsync(identity).ConfigureAwait(false);
 
         var userId = user.Id;
 
@@ -63,8 +71,8 @@ public class UserSyncService
                 .ConfigureAwait(false);
         }
 
-        // RBAC applies permissions/library access and re-enables the account, persisting via
-        // UpdatePolicyAsync (the only path that saves Permission/Preference changes).
+        // RBAC applies permissions/library access, persisting via UpdatePolicyAsync (the only
+        // path that saves Permission/Preference changes).
         await _rbacService.ApplyRoleMappingsAsync(userId, roles).ConfigureAwait(false);
         await _profileImageService.ApplyProfileImageAsync(userId, pictureUrl).ConfigureAwait(false);
 

--- a/README.md
+++ b/README.md
@@ -163,9 +163,37 @@ Browser                    Jellyfin Plugin              Identity Provider
 2. Plugin redirects to the IdP's authorization endpoint (with PKCE)
 3. User authenticates at the IdP
 4. IdP redirects back with an authorization code
-5. Plugin exchanges the code for tokens, extracts roles from the configured claim path
-6. Plugin creates/updates the Jellyfin user and applies role-based permissions
-7. Plugin issues a Jellyfin session token and redirects to the dashboard
+5. Plugin exchanges the code for tokens and validates the ID token
+6. Plugin extracts roles from the configured claim path
+7. Plugin creates/updates the Jellyfin user and applies role-based permissions
+8. Plugin issues a Jellyfin session token and redirects to the dashboard
+
+### Token validation
+
+The ID token is verified against the signing keys published at the provider's JWKS endpoint
+before any of its claims are used:
+
+| Check | Enforced |
+| --- | --- |
+| Signature (RSA/ECDSA only — `none` and HMAC rejected) | Yes |
+| Issuer matches the discovery document | Yes |
+| Audience matches the configured Client ID | Yes |
+| Expiry (2 minute clock skew allowance) | Yes |
+| `nonce` matches the authorize request | Yes |
+
+Discovery documents and signing keys are cached per provider and refreshed automatically, so
+logins do not add round trips to the IdP. Key rotation is handled: a token signed by an unknown
+key triggers one JWKS refresh and retry before the login fails.
+
+A provider that returns no `id_token` is rejected. If you see this, the client is likely
+configured as a plain OAuth2 client, or the `openid` scope is missing from the Scopes field.
+
+Access tokens are also read, since some providers place group/role claims only there (Keycloak's
+`realm_access.roles` is the common case). They are signature-, issuer- and expiry-checked the same
+way; only the audience check is skipped, because an access token is minted for a resource server
+rather than for Jellyfin. An access token that fails validation is ignored rather than trusted —
+the affected user loses their role claims rather than gaining any. Identity itself always comes
+from the ID token.
 
 ## Mobile & native apps (Quick Connect)
 
@@ -294,6 +322,12 @@ make build
 make docker-build
 ```
 
+### Test
+
+```bash
+dotnet test jellyfin-plugin-oidc.sln
+```
+
 ### Package (installable zip)
 
 ```bash
@@ -325,10 +359,14 @@ Jellyfin.Plugin.OIDC/
     OidcAuthProvider.cs          # Blocks password login for SSO users
   Services/
     StateManager.cs              # Thread-safe OIDC state with TTL
+    TokenValidator.cs            # JWKS-backed ID/access token validation
     ClaimParser.cs               # JWT claim extraction (nested paths)
     RbacService.cs               # Role-to-permission mapping engine
     UserSyncService.cs           # User provisioning and sync
+    ProfileImageService.cs       # Avatar sync from the picture claim
     ServiceRegistrator.cs        # DI registration
+Jellyfin.Plugin.OIDC.Tests/
+  TokenValidatorTests.cs         # Token forgery / misdirection rejection tests
 ```
 
 ## License

--- a/jellyfin-plugin-oidc.sln
+++ b/jellyfin-plugin-oidc.sln
@@ -1,19 +1,48 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.OIDC", "Jellyfin.Plugin.OIDC\Jellyfin.Plugin.OIDC.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.OIDC.Tests", "Jellyfin.Plugin.OIDC.Tests\Jellyfin.Plugin.OIDC.Tests.csproj", "{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x86.Build.0 = Debug|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x86.Build.0 = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|x64.Build.0 = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Debug|x86.Build.0 = Debug|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|x64.ActiveCfg = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|x64.Build.0 = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|x86.ActiveCfg = Release|Any CPU
+		{9225D4EB-F21C-48B2-8ED1-C15301D0FCAE}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Human note!

Hey, thanks for maintaining/creating this plugin - I am working on integrating it into my own setup, just raising a few PRs - feel free to close, merge, whatever. 

- Sam

---

> **Stacked on #25.** Until that merges, this PR's diff also contains its commit. Review the
> second commit only. Opening as a draft because the first half is a design change to documented
> behaviour and I would rather agree the shape with you than present it as finished.

## Problem 1 — accounts are keyed on a mutable claim

`UserSyncService` calls `GetUserByName(preferred_username)` on every login. That claim is
mutable and reassignable at the IdP, so it is not an identifier (OIDC Core §5.7 is explicit
about this — `sub` is the only claim an RP can rely on). Two consequences:

- a user **renamed at the IdP** silently gets a second, empty Jellyfin account, and their watch
  history is stranded on the old one
- a username later **reassigned to someone else** hands that person the previous holder's
  account, history and all

On an established server there is a third case: an IdP account can claim a local account it has
no relationship to, simply by matching its name. `MIGRATION.md` documents the name match as a
feature, and it genuinely is one — it is what lets an existing server migrate without losing
data. This PR keeps that, but narrows it to the one moment it is needed.

## Problem 2 — no deprovisioning

`RbacService.ApplyRoleMappingsAsync` returns early when a user's roles match no mapping, leaving
the policy untouched. So removing someone's admin role at the IdP leaves them an administrator
in Jellyfin indefinitely.

Separately, `policy.IsDisabled = false` was set unconditionally on every login, so an account
disabled in the Jellyfin UI came back on the next SSO login. `MIGRATION.md` already documents
this as a caveat.

## Change

**Accounts are keyed on `iss` + `sub`.** Links are recorded in the plugin configuration, since
Jellyfin's user model has nowhere to store an external identity. Once a link exists it takes
precedence and no name matching happens again — so a rename at either end is harmless.

**The name match survives as a one-time, guarded, recorded event.** It is refused when:

- the account is already linked to a different subject
- the account is managed by another authentication provider
- the account is an **administrator** — always, no override. Put an identity on an admin account
  by seeding its link, which resolves by subject and never reaches the username fallback.
- `LinkingMode` is `Strict`, which turns the fallback off entirely once migration is done

Adoption is logged at warning level, so there is a trail of which identity took which account.

**Deprovisioning:** a login whose roles match no mapping now revokes administrator and changes
nothing else. That is the part that has to happen; leaving the rest of the policy alone means a
mistyped mapping cannot lock people out of their media. `IsDisabled` is now cleared only when a
mapping actually matches, so disabling someone in the UI sticks.

## Refactor

Extracts `UserResolver` from `UserSyncService`, and puts configuration access behind
`IConfigurationStore`. Both exist so this logic can be tested without a running Jellyfin host —
`RbacService` in particular reads `OidcPlugin.Instance` directly, which makes it untestable.

This is the part most likely to be unwelcome, and I am happy to restructure it however you
prefer. Writing the tests immediately caught a regression I had introduced in the collapse
(a matched mapping no longer re-enabled a disabled account), which is the argument for them.

## Tests

17 tests: the adoption refusals, rename in both directions, `Strict` mode still honouring
existing links, relinking after an account is deleted, case-sensitivity of subject comparison,
and the deprovisioning paths.

## Compatibility

Defaults preserve existing behaviour for a fresh install: `LinkingMode` defaults to
`MigrateByUsername`, so first logins still adopt by name.

Three behaviour changes on upgrade, all deliberate:

1. Existing users get a link recorded on their next login. No visible change.
2. An IdP identity whose name matches an **administrator** account can no longer log in; it
   needs an explicit link. This is intentional — it is the collision with the worst outcome.
3. A user whose roles match no mapping loses administrator instead of keeping it.

Happy to make (2) and (3) configurable if you would rather not change defaults.

Tested against Keycloak 26 on a server with 36 existing local accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
