### PR TITLE
Prevent persistent OIDC button

### DIFF
--- a/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
@@ -30,7 +30,7 @@ public class LoginButtonController : ControllerBase
         sb.AppendLine("  var _p = window.location.pathname.split('/web/');");
         sb.AppendLine("  var basePath = _p.length > 1 ? _p[0] : '';");
         sb.AppendLine("  function addButtons() {");
-        sb.AppendLine("    var form = document.querySelector('.manualLoginForm, #loginPage form, [data-role=\"page\"] form');");
+        sb.AppendLine("    var form = document.querySelector('.manualLoginForm, #loginPage form');");
         sb.AppendLine("    if (!form || document.getElementById('oidc-sso-buttons')) return;");
         sb.AppendLine("    var container = document.createElement('div');");
         sb.AppendLine("    container.id = 'oidc-sso-buttons';");

--- a/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
@@ -29,7 +29,7 @@ public class LoginButtonController : ControllerBase
         // under '<basePath>/web/', so derive the prefix from the login page URL. Empty when unset.
         sb.AppendLine("  var _p = window.location.pathname.split('/web/');");
         sb.AppendLine("  var basePath = _p.length > 1 ? _p[0] : '';");
-        sb.AppendLine("  var observer = new MutationObserver(function(mutations, obs) {");
+        sb.AppendLine("  function addButtons() {");
         sb.AppendLine("    var form = document.querySelector('.manualLoginForm, #loginPage form');");
         sb.AppendLine("    if (!form || document.getElementById('oidc-sso-buttons')) return;");
         sb.AppendLine("    var container = document.createElement('div');");
@@ -60,13 +60,13 @@ public class LoginButtonController : ControllerBase
         sb.AppendLine("    container.appendChild(sep);");
         sb.AppendLine("    form.parentNode.insertBefore(container, form);");
         // Stop listening for mutations.
-        sb.AppendLine("    obs.disconnect();");
+        sb.AppendLine("    observer.disconnect();");
         sb.AppendLine("  }");
+        ab.AppendLine("  var observer = new MutationObserver(addButtons);");
         sb.AppendLine("  observer.observe(document.body, { childList: true, subtree: true });");
         // Safety fallback: stop observing after 30 seconds if no login form appears
-        sb.AppendLine("  setTimeout(function() {");
-        sb.AppendLine("    observer.disconnect();");
-        sb.AppendLine("  }, 30000);");
+        sb.AppendLine("  addButtons();");
+        sb.AppendLine("  setTimeout(function () { observer.disconnect(); }, 30000);");
         sb.AppendLine("})();");
 
         return Content(sb.ToString(), "application/javascript");

--- a/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
@@ -29,7 +29,7 @@ public class LoginButtonController : ControllerBase
         // under '<basePath>/web/', so derive the prefix from the login page URL. Empty when unset.
         sb.AppendLine("  var _p = window.location.pathname.split('/web/');");
         sb.AppendLine("  var basePath = _p.length > 1 ? _p[0] : '';");
-        sb.AppendLine("  function addButtons() {");
+        sb.AppendLine("  var observer = new MutationObserver(function(mutations, obs) {");
         sb.AppendLine("    var form = document.querySelector('.manualLoginForm, #loginPage form');");
         sb.AppendLine("    if (!form || document.getElementById('oidc-sso-buttons')) return;");
         sb.AppendLine("    var container = document.createElement('div');");
@@ -59,10 +59,14 @@ public class LoginButtonController : ControllerBase
         sb.AppendLine("    sep.textContent = '— or sign in with password —';");
         sb.AppendLine("    container.appendChild(sep);");
         sb.AppendLine("    form.parentNode.insertBefore(container, form);");
+        // Stop listening for mutations.
+        sb.AppendLine("    obs.disconnect();");
         sb.AppendLine("  }");
-        sb.AppendLine("  var observer = new MutationObserver(addButtons);");
         sb.AppendLine("  observer.observe(document.body, { childList: true, subtree: true });");
-        sb.AppendLine("  addButtons();");
+        // Safety fallback: stop observing after 30 seconds if no login form appears
+        sb.AppendLine("  setTimeout(function() {");
+        sb.AppendLine("    observer.disconnect();");
+        sb.AppendLine("  }, 30000);");
         sb.AppendLine("})();");
 
         return Content(sb.ToString(), "application/javascript");

--- a/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
@@ -62,10 +62,10 @@ public class LoginButtonController : ControllerBase
         // Stop listening for mutations.
         sb.AppendLine("    observer.disconnect();");
         sb.AppendLine("  }");
-        ab.AppendLine("  var observer = new MutationObserver(addButtons);");
+        sb.AppendLine("  var observer = new MutationObserver(addButtons);");
         sb.AppendLine("  observer.observe(document.body, { childList: true, subtree: true });");
-        // Safety fallback: stop observing after 30 seconds if no login form appears
         sb.AppendLine("  addButtons();");
+        // Safety fallback: stop observing after 30 seconds if no login form appears
         sb.AppendLine("  setTimeout(function () { observer.disconnect(); }, 30000);");
         sb.AppendLine("})();");
 


### PR DESCRIPTION
## Issue

The injected SSO login banner (served from `/sso/OIDC/LoginButtons`) shows up on individual media info pages.

Example: 
<img width="3677" height="1252" alt="Screenshot From 2026-09-10 10-28-22" src="https://github.com/user-attachments/assets/a514a784-a1da-493a-aa1c-1719590b1399" />

## Cause

In `LoginButtonController.cs`, `addButtons()` gates on this selector:

```js
var form = document.querySelector('.manualLoginForm, #loginPage form, [data-role="page"] form');
```

`[data-role="page"] form` is broad enough that it appears to match other form elements on the page, like the `#trackSelections` form on media info pages.

Separately, the `MutationObserver`:

```js
var observer = new MutationObserver(addButtons); 
observer.observe(document.body, { childList: true, subtree: true });
```

is attached once and never disconnected, so it keeps re-running `addButtons()` on every DOM mutation for the entire lifetime of the page

## Reproduction

1. Install the plugin, enable an OIDC provider with the login-button script injected (via Branding snippet or reverse-proxy injection).
2. Open the Jellyfin app on web.
3. Go to a movie or episode page.
4. Observe the SSO sign-in banner appearing above the trackSelections form.

## Environment

- Jellyfin server: `10.11.11` and `12.0`
- jellyfin-plugin-oidc: v1.0.8
- Client: Web

## Note

I did not check the login page layout of prior versions of Jellyfin, to see if the existing broad selector (`[data-role="page"] form`) is required in other versions.