### PR TITLE
Update manifest.json for v1.0.9

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,12 +8,12 @@
     "category": "Authentication",
     "versions": [
       {
-        "version": "1.0.8.0",
-        "changelog": "Native/mobile app SSO via Quick Connect; fix Jellyfin base URL handling\n\n- Native/mobile apps (Android, iOS, Android TV) can now sign in via SSO using Jellyfin Quick Connect: authenticate in a browser, then enter the 6-digit code shown by the app. The web login button only works in the browser client, so Quick Connect bridges native apps.\n- Fix: generated SSO links now honor a Jellyfin base URL (Networking > Base URL). Previously the callback redirected to /sso/OIDC/Auth without the base path and returned 404 on prefixed deployments (#19).",
+        "version": "1.0.9.0",
+        "changelog": "Validate ID token signature, issuer, audience and expiry\n\nUPGRADE NOTE: logins will now fail for providers that return no id_token (a plain OAuth2 client rather than OIDC) or that sign ID tokens with HS256; the reason is written to the Jellyfin server log. Providers that return an id_token signed with RS256/ECDSA — the default nearly everywhere — are unaffected. Validate ID tokens cryptographically before trusting their claims: signature against the provider's published JWKS keys (RSA/ECDSA only), issuer, audience (your Client ID) and expiry, with automatic key-rotation handling. Previously tokens were only base64-decoded, so a token minted for a different client in the same realm, or an expired one, was accepted — and those claims drive account provisioning and the administrator flag. Access tokens are now verified before roles or picture claims are read from them, and a provider returning no id_token fails the login instead of silently falling back to the access token. Adds the project's first test suite and a CI workflow.",
         "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/Ezeqielle/jellyfin-plugin-oidc/releases/download/v1.0.8/oidc-rbac.zip",
-        "checksum": "d41a0b3792a51b50432c2a6710d10160",
-        "timestamp": "2026-07-15T11:34:26Z"
+        "sourceUrl": "https://github.com/Ezeqielle/jellyfin-plugin-oidc/releases/download/v1.0.9/oidc-rbac.zip",
+        "checksum": "f930de576af3a4a1b7c282c9536df6ce",
+        "timestamp": "2026-09-10T20:30:31Z"
       }
     ]
   }


### PR DESCRIPTION
Manifest bump publishing v1.0.9 to the plugin catalog.

The release workflow pushed this branch but could not open the PR itself — `gh pr create` failed with `GitHub Actions is not permitted to create or approve pull requests`, which is the repo setting *Settings → Actions → General → Allow GitHub Actions to create and approve pull requests*. Opening it manually.

Verified against the published release:
- version `1.0.9.0`, targetAbi `10.11.0.0`
- checksum `f930de576af3a4a1b7c282c9536df6ce` matches the release asset
- sourceUrl points at the v1.0.9 `oidc-rbac.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)