### PR TITLE
ci: parse the generated login-button script, stop masking release failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,16 @@ jobs:
 
       - name: Test
         run: dotnet test jellyfin-plugin-oidc.sln -c Release --no-build
+
+      # The login-button script is built by string concatenation, so the C# compiler never
+      # sees the JavaScript. Parse the rendered output with a real engine — a syntax error
+      # here removes every SSO button from the login page without logging anything.
+      - name: Check generated login-button script parses
+        run: |
+          SCRIPT=$(find . -name 'login-buttons.generated.js' -path '*/bin/*' | head -1)
+          if [ -z "$SCRIPT" ]; then
+            echo "::error::No rendered script found. Did LoginButtonScriptTests run?"
+            exit 1
+          fi
+          echo "Checking $SCRIPT"
+          node --check "$SCRIPT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,17 @@ jobs:
           fi
           git commit -m "Update manifest.json for ${GITHUB_REF_NAME}"
           git push -f origin "$BRANCH"
+
+          # Check for an existing PR explicitly rather than swallowing every `gh pr create`
+          # failure with `|| echo`. That fallback once reported "PR already exists" when the
+          # real error was "GitHub Actions is not permitted to create or approve pull
+          # requests" — the job went green while the catalog was never updated, so a release
+          # looked shipped and reached nobody.
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "PR already exists for $BRANCH; branch updated in place"
+            exit 0
+          fi
+
           gh pr create --base main --head "$BRANCH" \
             --title "Update manifest.json for ${GITHUB_REF_NAME}" \
-            --body "Automated manifest bump for the ${GITHUB_REF_NAME} release. Merge to publish it to the plugin catalog." \
-            || echo "PR already exists for $BRANCH; branch updated in place"
+            --body "Automated manifest bump for the ${GITHUB_REF_NAME} release. Merge to publish it to the plugin catalog."

--- a/Jellyfin.Plugin.OIDC.Tests/LoginButtonScriptTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/LoginButtonScriptTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using Jellyfin.Plugin.OIDC.Api;
+using Jellyfin.Plugin.OIDC.Configuration;
+using Xunit;
+
+namespace Jellyfin.Plugin.OIDC.Tests;
+
+/// <summary>
+/// The login-button script is assembled from string fragments, so the C# build checks nothing
+/// about the JavaScript it produces. Two separate changes have now shipped a script that failed
+/// to parse, and the failure mode is silent: the browser drops the whole script, every SSO
+/// button disappears from the login page, and the server logs nothing.
+///
+/// <see cref="DelimitersBalance"/> catches that class of break in-process. CI additionally runs
+/// `node --check` over the file written by <see cref="RendersScriptArtifact"/>, which is the
+/// authoritative check — a real parser rather than a counter.
+/// </summary>
+public class LoginButtonScriptTests
+{
+    /// <summary>Name CI looks for under the test output directory.</summary>
+    private const string ArtifactName = "login-buttons.generated.js";
+
+    /// <summary>
+    /// Deliberately awkward: an apostrophe in the display name exercises the quote escaping,
+    /// and parentheses in a provider name would unbalance a naive delimiter count if they ever
+    /// leaked out of their string literal.
+    /// </summary>
+    private static readonly OidcProviderConfig[] Providers =
+    {
+        new()
+        {
+            ProviderId = "authentik",
+            DisplayName = "authentik",
+            ButtonColor = "#fd4b2d",
+            Enabled = true
+        },
+        new()
+        {
+            ProviderId = "keycloak",
+            DisplayName = "Bob's IdP (staging)",
+            ButtonColor = "#4285F4",
+            Enabled = true
+        }
+    };
+
+    [Fact]
+    public void EveryProviderGetsBothLinks()
+    {
+        var script = LoginButtonController.BuildScript(Providers);
+
+        foreach (var provider in Providers)
+        {
+            Assert.Contains($"/sso/OIDC/Start/{provider.ProviderId}", script, StringComparison.Ordinal);
+            Assert.Contains($"/sso/OIDC/QuickConnect/{provider.ProviderId}", script, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void OnlyAttachesToTheLoginForm()
+    {
+        var script = LoginButtonController.BuildScript(Providers);
+
+        // '[data-role="page"] form' matched forms on ordinary pages too — notably
+        // '.trackSelections' on item detail pages, which put the SSO banner above the
+        // audio/subtitle selectors. See #29.
+        Assert.DoesNotContain("data-role", script, StringComparison.Ordinal);
+        Assert.Contains(".manualLoginForm", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ObserverIsDeclaredBeforeUse()
+    {
+        var script = LoginButtonController.BuildScript(Providers);
+
+        // A `sb`/`ab` typo once emitted `observer.observe(...)` with no declaration. That is
+        // valid syntax, so `node --check` would pass it — only a reference check catches it.
+        Assert.Contains("var observer = new MutationObserver(", script, StringComparison.Ordinal);
+        Assert.True(
+            script.IndexOf("var observer =", StringComparison.Ordinal)
+            < script.IndexOf("observer.observe(", StringComparison.Ordinal),
+            "observer must be declared before it is used");
+    }
+
+    [Fact]
+    public void RunsOnceImmediatelyAndStopsObservingAfterInserting()
+    {
+        var script = LoginButtonController.BuildScript(Providers);
+
+        // Without the immediate call the buttons never appear when the form is already in the
+        // DOM at injection time, which is the common case for the Branding snippet. Matching
+        // the call rather than a whole line keeps this off Environment.NewLine.
+        Assert.Contains("addButtons();", script, StringComparison.Ordinal);
+        Assert.Contains("observer.disconnect();", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DelimitersBalance()
+    {
+        var script = LoginButtonController.BuildScript(Providers);
+
+        Assert.Equal(Count(script, '('), Count(script, ')'));
+        Assert.Equal(Count(script, '{'), Count(script, '}'));
+        Assert.Equal(Count(script, '['), Count(script, ']'));
+    }
+
+    /// <summary>
+    /// Writes the rendered script next to the test binaries so the CI job can run a real
+    /// JavaScript parser over it. Asserting the file is non-empty keeps a silently skipped
+    /// write from letting the CI step pass on a stale artifact.
+    /// </summary>
+    [Fact]
+    public void RendersScriptArtifact()
+    {
+        var script = LoginButtonController.BuildScript(Providers);
+        var path = Path.Combine(AppContext.BaseDirectory, ArtifactName);
+
+        File.WriteAllText(path, script);
+
+        Assert.True(File.Exists(path));
+        Assert.NotEmpty(File.ReadAllText(path));
+    }
+
+    private static int Count(string value, char c)
+    {
+        var total = 0;
+        foreach (var ch in value)
+        {
+            if (ch == c)
+            {
+                total++;
+            }
+        }
+
+        return total;
+    }
+}

--- a/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/LoginButtonController.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Jellyfin.Plugin.OIDC.Configuration;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Jellyfin.Plugin.OIDC.Api;
@@ -23,6 +25,19 @@ public class LoginButtonController : ControllerBase
             return Content("", "application/javascript");
         }
 
+        return Content(BuildScript(providers), "application/javascript");
+    }
+
+    /// <summary>
+    /// Builds the injected login-button script.
+    ///
+    /// Internal so the test suite can render it without a running host: this is assembled from
+    /// string fragments, so nothing in the C# build checks that the result is valid JavaScript,
+    /// and a syntax error here silently removes every SSO button from the login page rather
+    /// than failing loudly. CI runs `node --check` over the rendered output.
+    /// </summary>
+    internal static string BuildScript(IReadOnlyList<OidcProviderConfig> providers)
+    {
         var sb = new StringBuilder();
         sb.AppendLine("(function() {");
         // Jellyfin may run under a base path (Networking > Base URL). The web client is served
@@ -69,7 +84,7 @@ public class LoginButtonController : ControllerBase
         sb.AppendLine("  setTimeout(function () { observer.disconnect(); }, 30000);");
         sb.AppendLine("})();");
 
-        return Content(sb.ToString(), "application/javascript");
+        return sb.ToString();
     }
 
     [HttpGet("BrandingSnippet")]


### PR DESCRIPTION
Two silent failures this repo hit tonight, and the guards for them.

## The login-button script is never parsed

It is assembled with `StringBuilder`, so the C# build never sees the JavaScript. #29 shipped a missing paren, and its follow-up an `ab`/`sb` typo — each producing a script the browser refuses outright, which removes every SSO button from the login page and logs nothing.

- Extracts `LoginButtonController.BuildScript` so it can be rendered without a running host (`internal`, using the `InternalsVisibleTo` added in #25).
- Adds `LoginButtonScriptTests` covering what actually broke: the observer being declared before use, the immediate `addButtons()` call, the narrowed selector, and balanced delimiters.
- CI runs `node --check` over the rendered script — the authoritative check, since a delimiter count is only a proxy.

The two checks are complementary: `node --check` catches the missing paren but *not* the `ab` typo (an undeclared `observer` is valid syntax), while the C# build catches the typo and not the paren. Hence both, plus an explicit declared-before-use assertion.

## The release workflow reported success while doing nothing

The manifest step ended with `gh pr create ... || echo "PR already exists"`. That `||` swallowed a completely different error — `GitHub Actions is not permitted to create or approve pull requests` — so the v1.0.9 job went green while the catalog was never updated. The release looked shipped and reached nobody; it needed a manually opened PR (#31).

Now checks for an existing PR explicitly, and lets any other failure fail the job.

**This does not fix the root cause.** That needs *Settings → Actions → General → Allow GitHub Actions to create and approve pull requests*, which is a repo setting rather than a file. Until it is enabled, releases will fail loudly at this step instead of silently succeeding — which is the intended improvement, but it does mean the next release stops there until either the setting is flipped or the PR is opened by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)