### PR TITLE
Update manifest.json for v1.0.10

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,12 +8,12 @@
     "category": "Authentication",
     "versions": [
       {
-        "version": "1.0.9.0",
-        "changelog": "Validate ID token signature, issuer, audience and expiry\n\nUPGRADE NOTE: logins will now fail for providers that return no id_token (a plain OAuth2 client rather than OIDC) or that sign ID tokens with HS256; the reason is written to the Jellyfin server log. Providers that return an id_token signed with RS256/ECDSA — the default nearly everywhere — are unaffected. Validate ID tokens cryptographically before trusting their claims: signature against the provider's published JWKS keys (RSA/ECDSA only), issuer, audience (your Client ID) and expiry, with automatic key-rotation handling. Previously tokens were only base64-decoded, so a token minted for a different client in the same realm, or an expired one, was accepted — and those claims drive account provisioning and the administrator flag. Access tokens are now verified before roles or picture claims are read from them, and a provider returning no id_token fails the login instead of silently falling back to the access token. Adds the project's first test suite and a CI workflow.",
+        "version": "1.0.10.0",
+        "changelog": "Fix the SSO sign-in banner appearing on media item pages\n\nThe injected login-button script matched any form on any page, so the banner rendered above the audio/subtitle selectors on movie and episode pages. It now attaches only to the login form, inserts the buttons once, and stops watching the DOM afterwards. Thanks to @brianporeilly for the report and the fix.",
         "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/Ezeqielle/jellyfin-plugin-oidc/releases/download/v1.0.9/oidc-rbac.zip",
-        "checksum": "f930de576af3a4a1b7c282c9536df6ce",
-        "timestamp": "2026-09-10T20:30:31Z"
+        "sourceUrl": "https://github.com/Ezeqielle/jellyfin-plugin-oidc/releases/download/v1.0.10/oidc-rbac.zip",
+        "checksum": "81249667a265a6757cf010c23196f020",
+        "timestamp": "2026-09-10T21:05:22Z"
       }
     ]
   }


### PR DESCRIPTION
Manifest bump publishing v1.0.10 to the plugin catalog.

Opened by hand: the release workflow pushed this branch but cannot create the PR itself, because *Settings → Actions → General → Allow GitHub Actions to create and approve pull requests* is off. Since #32 that failure is reported as a real error rather than hidden behind a misleading success message, which is why the release run shows red — the release itself built and published fine.

Verified against the published release:
- version `1.0.10.0`, targetAbi `10.11.0.0`
- checksum `81249667a265a6757cf010c23196f020`
- sourceUrl points at the v1.0.10 `oidc-rbac.zip` (420400 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)